### PR TITLE
fix executables ruby files generation

### DIFF
--- a/sensu-plugins-redis.gemspec
+++ b/sensu-plugins-redis.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.date                   = Date.today.to_s
   s.description            = 'Sensu plugins for redis'
   s.email                  = '<sensu-users@googlegroups.com>'
-  s.executables            = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.executables            = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-redis'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => '@mattyjones',


### PR DESCRIPTION
Issue:
<pre><code>
$ gem fetch sensu-plugins-redis
Downloaded sensu-plugins-redis-0.0.2
$ tar -xzOf sensu-plugins-redis-0.0.2.gem metadata.gz | gzip -d | awk '/^executables/,/^extensions/'
executables: []
extensions: []
</code></pre>

after fix:
<pre><code>
$ gem build -V sensu-plugins-redis.gemspec
$ tar -xzOf sensu-plugins-redis-0.0.2.gem metadata.gz | gzip -d | awk '/^executables/,/^extensions/'
executables:
- check-redis-info.rb
- check-redis-list-length.rb
- check-redis-memory.rb
- check-redis-ping.rb
- check-redis-slave-status.rb
- metrics-redis-graphite.rb
- metrics-redis-llen.rb
extensions: []
</code></pre>