### PR TITLE
Fix executable config

### DIFF
--- a/sensu-plugins-redis.gemspec
+++ b/sensu-plugins-redis.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.date                   = Date.today.to_s
   s.description            = 'Sensu plugins for redis'
   s.email                  = '<sensu-users@googlegroups.com>'
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*.rb') + %w(LICENSE README.md CHANGELOG.md)
   s.executables            = Dir.glob('bin/**/*').map { |file| File.basename(file) }
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-redis'
   s.license                = 'MIT'

--- a/sensu-plugins-redis.gemspec
+++ b/sensu-plugins-redis.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.description            = 'Sensu plugins for redis'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
-  s.executables            = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  s.executables            = Dir.glob('bin/**/*').map { |file| File.basename(file) }
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-redis'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => '@mattyjones',


### PR DESCRIPTION
In the current version of the gemspec the configuration of the executables does not work. Symptom: they are not copied to `/opt/sensu/embedded/bin/` as all the other executables of other plugins are.

This change fixes the configuration.