### PR TITLE
fix variable interpolation, using double quotes

### DIFF
--- a/bin/check-redis-memory-percentage.rb
+++ b/bin/check-redis-memory-percentage.rb
@@ -84,9 +84,9 @@ class RedisChecks < Sensu::Plugin::Check::CLI
     if used_memory >= crit_memory
       critical "Redis running on #{config[:host]}:#{config[:port]} is above the CRITICAL limit: #{used_memory}% used / #{crit_memory}%"
     elsif used_memory >= warn_memory
-      warning "Redis running on #{config[:host]}:#{config[:port]} is above the WARNING limit: #{used_memory} % used / #{warn_memory}%"
+      warning "Redis running on #{config[:host]}:#{config[:port]} is above the WARNING limit: #{used_memory}% used / #{warn_memory}%"
     else
-      ok "Redis memory usage: #{used_memory} is below defined limits"
+      ok "Redis memory usage: #{used_memory}% is below defined limits"
     end
   rescue
     message = "Could not connect to Redis server on #{config[:host]}:#{config[:port]}"

--- a/bin/check-redis-memory-percentage.rb
+++ b/bin/check-redis-memory-percentage.rb
@@ -6,7 +6,7 @@
 #   check redis memory usage in percentage
 #
 # OUTPUT:
-#   Criticality of memory usage by redis
+#   Criticality of memory usage by redis. Eg: https://git.io/vaQpe
 #
 # PLATFORMS:
 #   Linux but not tested (Windows, BSD, Solaris, etc)
@@ -86,7 +86,7 @@ class RedisChecks < Sensu::Plugin::Check::CLI
     elsif used_memory >= warn_memory
       warning "Redis running on #{config[:host]}:#{config[:port]} is above the WARNING limit: #{used_memory} % used / #{warn_memory}%"
     else
-      ok 'Redis memory usage: #{used_memory} is below defined limits'
+      ok "Redis memory usage: #{used_memory} is below defined limits"
     end
   rescue
     message = "Could not connect to Redis server on #{config[:host]}:#{config[:port]}"

--- a/bin/check-redis-memory.rb
+++ b/bin/check-redis-memory.rb
@@ -61,11 +61,11 @@ class RedisChecks < Sensu::Plugin::Check::CLI
     warn_memory = config[:warn_mem]
     crit_memory = config[:crit_mem]
     if used_memory >= crit_memory
-      critical "Redis running on #{config[:host]}:#{config[:port]} is above the CRITICAL limit: #{used_memory} KB used / #{crit_memory} KB limit"
+      critical "Redis running on #{config[:host]}:#{config[:port]} is above the CRITICAL limit: #{used_memory}KB used / #{crit_memory}KB limit"
     elsif used_memory >= warn_memory
-      warning "Redis running on #{config[:host]}:#{config[:port]} is above the WARNING limit: #{used_memory} KB used / #{warn_memory} KB limit"
+      warning "Redis running on #{config[:host]}:#{config[:port]} is above the WARNING limit: #{used_memory}KB used / #{warn_memory}KB limit"
     else
-      ok 'Redis memory usage is below defined limits'
+      ok "Redis memory usage: #{used_memory}KB is below defined limits"
     end
   rescue
     message = "Could not connect to Redis server on #{config[:host]}:#{config[:port]}"

--- a/bin/check-redis-memory.rb
+++ b/bin/check-redis-memory.rb
@@ -65,7 +65,7 @@ class RedisChecks < Sensu::Plugin::Check::CLI
     elsif used_memory >= warn_memory
       warning "Redis running on #{config[:host]}:#{config[:port]} is above the WARNING limit: #{used_memory} KB used / #{warn_memory} KB limit"
     else
-      ok "Redis memory usage is below defined limits"
+      ok 'Redis memory usage is below defined limits'
     end
   rescue
     message = "Could not connect to Redis server on #{config[:host]}:#{config[:port]}"

--- a/bin/check-redis-memory.rb
+++ b/bin/check-redis-memory.rb
@@ -65,7 +65,7 @@ class RedisChecks < Sensu::Plugin::Check::CLI
     elsif used_memory >= warn_memory
       warning "Redis running on #{config[:host]}:#{config[:port]} is above the WARNING limit: #{used_memory} KB used / #{warn_memory} KB limit"
     else
-      ok 'Redis memory usage is below defined limits'
+      ok "Redis memory usage is below defined limits"
     end
   rescue
     message = "Could not connect to Redis server on #{config[:host]}:#{config[:port]}"


### PR DESCRIPTION
## this is a just a fix
**Is this in reference to an existing issue?**
Yes,  addressing #14 
with regard to the silly mistake i made,
![ruby_variable_dont_expand_inside_single_quotes](https://cloud.githubusercontent.com/assets/1695906/14224557/31a23eb6-f8c0-11e5-9864-db86ce02151e.png)
 
#### Purpose
Since variables inside the single quotes don't expand so
 output when ok used to yeild something like this:

![cf_sing_quotes_discuss_monitoringlove](https://cloud.githubusercontent.com/assets/1695906/14224566/c8ac2e16-f8c0-11e5-95a2-6806c7c44fba.png)



