### PR TITLE
use double quotes so the variable is interpolated

### DIFF
--- a/bin/check-redis-memory-percentage.rb
+++ b/bin/check-redis-memory-percentage.rb
@@ -86,7 +86,7 @@ class RedisChecks < Sensu::Plugin::Check::CLI
     elsif used_memory >= warn_memory
       warning "Redis running on #{config[:host]}:#{config[:port]} is above the WARNING limit: #{used_memory} % used / #{warn_memory}%"
     else
-      ok 'Redis memory usage: #{used_memory} is below defined limits'
+      ok "Redis memory usage: #{used_memory} is below defined limits"
     end
   rescue
     message = "Could not connect to Redis server on #{config[:host]}:#{config[:port]}"


### PR DESCRIPTION
Use double-quotes so ``#{used_memory}`` is interpolated in the ``check-redis-memory-percentage.rb`` check.