### PR TITLE
use maxmemory property from redis info if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - metrics-redis-graphite: add commandstats metrics (@PhilGuay)
+### Changed
+- check-redis-memory-percentage use maxmemory property if available
 
 ## [1.0.0] - 2016-05-23
 ### Added


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

check-redis-memory-percent: use maxmemory property from redis info if available. If not, fall back to using `/proc/meminfo`

#### Known Compatablity Issues
