### PR TITLE
check-redis-slave-status: do not throw error if server is master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - metrics-redis-graphite: add commandstats metrics (@PhilGuay)
 ### Changed
 - check-redis-memory-percentage use maxmemory property if available
+- check-redis-slave-status: do not throw error if server is master
 
 ## [1.0.0] - 2016-05-23
 ### Added

--- a/bin/check-redis-slave-status.rb
+++ b/bin/check-redis-slave-status.rb
@@ -31,7 +31,9 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
     options[:password] = config[:password] if config[:password]
     redis = Redis.new(options)
 
-    if redis.info.fetch('master_link_status') == 'up'
+    if redis.info.fetch('role') == 'master'
+      ok 'This redis server is master'
+    elsif redis.info.fetch('master_link_status') == 'up'
       ok 'The redis master links status is up!'
     else
       msg = ''
@@ -41,7 +43,7 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
     end
 
   rescue KeyError
-    critical "Redis server on #{config[:host]}:#{config[:port]} is master"
+    critical "Redis server on #{config[:host]}:#{config[:port]} is not master and does not have master_link_status"
 
   rescue
     critical "Could not connect to Redis server on #{config[:host]}:#{config[:port]}"


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** Yes #20 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

In check-redis-slave-status, do not throw error if server is master. References #20 where the check will report an error after redis sentinel changes the master after an outage.

#### Known Compatibility Issues

check-redis-slave-status.rb will no longer throw an error checking a redis server which is a master.
