### PR TITLE
check-redis-memory-percentage: .div() returns an int so convert back to float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - metrics-redis-graphite: add commandstats metrics (@PhilGuay)
 ### Changed
 - check-redis-memory-percentage use maxmemory property if available
+- check-redis-memory-percentage fix float conversion bug
 - check-redis-slave-status: do not throw error if server is master
 
 ## [1.0.0] - 2016-05-23

--- a/bin/check-redis-memory-percentage.rb
+++ b/bin/check-redis-memory-percentage.rb
@@ -80,8 +80,8 @@ class RedisChecks < Sensu::Plugin::Check::CLI
     redis = Redis.new(options)
 
     redis_info = redis.info
-    memory_in_use = redis_info.fetch('used_memory').to_f.div(1024)             # used memory in KB (KiloBytes)
-    total_memory = redis_info.fetch('maxmemory', system_memory).to_f.div(1024) # max memory (if specified) in KB
+    memory_in_use = redis_info.fetch('used_memory').to_f.div(1024).to_f             # used memory in KB (KiloBytes)
+    total_memory = redis_info.fetch('maxmemory', system_memory).to_f.div(1024).to_f # max memory (if specified) in KB
 
     used_memory = ((memory_in_use / total_memory) * 100).round(2)
     warn_memory = config[:warn_mem]


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

check-redis-memory-percentage: calling `.div(1024)` return an int, so we need to convert it back to a float to ensure the percentage is calculated correctly.

#### Known Compatablity Issues

