### PR TITLE
check-redis-memory-percentage: Use total memory if max is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- check-redis-memory-percentage: Handle case where maxmemory is 0 (@stevenviola)
+
 ## [1.1.1] - 2017-05-05
 ### Fixed
 - updated gemspec to avoid deprecation warnings in redis client for Fixnum

--- a/bin/check-redis-memory-percentage.rb
+++ b/bin/check-redis-memory-percentage.rb
@@ -80,8 +80,12 @@ class RedisChecks < Sensu::Plugin::Check::CLI
     redis = Redis.new(options)
 
     redis_info = redis.info
-    memory_in_use = redis_info.fetch('used_memory').to_f.div(1024).to_f             # used memory in KB (KiloBytes)
-    total_memory = redis_info.fetch('maxmemory', system_memory).to_f.div(1024).to_f # max memory (if specified) in KB
+    max_memory = redis_info.fetch('maxmemory', 0).to_f
+    if max_memory == 0
+      max_memory = redis_info.fetch('total_system_memory', system_memory).to_f
+    end
+    memory_in_use = redis_info.fetch('used_memory').to_f.div(1024).to_f # used memory in KB (KiloBytes)
+    total_memory = max_memory.div(1024).to_f                            # max memory (if specified) in KB
 
     used_memory = ((memory_in_use / total_memory) * 100).round(2)
     warn_memory = config[:warn_mem]

--- a/bin/check-redis-memory-percentage.rb
+++ b/bin/check-redis-memory-percentage.rb
@@ -80,12 +80,12 @@ class RedisChecks < Sensu::Plugin::Check::CLI
     redis = Redis.new(options)
 
     redis_info = redis.info
-    max_memory = redis_info.fetch('maxmemory', 0).to_f
+    max_memory = redis_info.fetch('maxmemory', 0).to_i
     if max_memory == 0
-      max_memory = redis_info.fetch('total_system_memory', system_memory).to_f
+      max_memory = redis_info.fetch('total_system_memory', system_memory).to_i
     end
-    memory_in_use = redis_info.fetch('used_memory').to_f.div(1024).to_f # used memory in KB (KiloBytes)
-    total_memory = max_memory.div(1024).to_f                            # max memory (if specified) in KB
+    memory_in_use = redis_info.fetch('used_memory').to_i.fdiv(1024) # used memory in KB (KiloBytes)
+    total_memory = max_memory.fdiv(1024)                            # max memory (if specified) in KB
 
     used_memory = ((memory_in_use / total_memory) * 100).round(2)
     warn_memory = config[:warn_mem]


### PR DESCRIPTION
#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [X] RuboCop passes

- [X] Existing tests pass 

#### Purpose

The change in #24 started using this variable from redis info, which is preferable than checking `/proc/meminfo`. If `maxmemory` is set to 0, the redis default, check-redis-memory-percentage will fail since it is dividing by 0. In this case, if `maxmemory` is 0, we should get the value from `total_system_memory` if available in the redis info, and use that in our memory percentage calculation.

This allows for using this check on a remote redis server (since checking `/proc/meminfo` would not work on a remote server), and handles the case where maxmemory is set to a real memory value, or set to the default value of 0.

#### Known Compatibility Issues

