### PR TITLE
fixes #22 issues with redis graphite incompatible metrics:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+## Fixed
+- Updated list of SKIP_KEYS_REGEX in metrics-redis-graphite.rb per #22 (@majormoses)
+
+## Added
+- Added option to override SKIP_KEYS_REGEX via option. (@majormoses)
 ## [1.2.0] - 2017-05-09
 ### Changed
 - check-redis-memory-percentage: Handle case where maxmemory is 0 (@stevenviola)


### PR DESCRIPTION
- added required keys to existing blacklist
- exposed an option to override the default blacklist to allow users to function without a new release if we need to add again.

## Pull Request Checklist
#22 
**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 


#### Purpose
Fix user issues with redis graphite metrics
#### Known Compatablity Issues
The change is backwards compatible.
