### PR TITLE
Allow to connect to Redis via Unix socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,21 @@
-#Change Log
+# Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- Added option to connect to Redis via Unix sockets. (@mbyczkowski)
+
 ## [1.2.2] - 2017-05-31
-## Fixed
+### Fixed
 - metrics-redis-graphite: fix skipkeys option not accepting any argument (@boutetnico)
 
 ## [1.2.1] - 2017-05-14
-## Fixed
+### Fixed
 - Updated list of SKIP_KEYS_REGEX in metrics-redis-graphite.rb per #22 and added an option to override the list of keys to allow users to deal with changes without the need of a release (@majormoses)
 
-## Added
+### Added
 - Added option to override SKIP_KEYS_REGEX via option. (@majormoses)
 ## [1.2.0] - 2017-05-09
 ### Changed

--- a/bin/check-redis-keys.rb
+++ b/bin/check-redis-keys.rb
@@ -14,6 +14,12 @@ require 'sensu-plugin/check/cli'
 require 'redis'
 
 class RedisKeysCheck < Sensu::Plugin::Check::CLI
+  option :socket,
+         short: '-s SOCKET',
+         long: '--socket SOCKET',
+         description: 'Redis socket to connect to (overrides Host and Port)',
+         required: false
+
   option :host,
          short: '-h HOST',
          long: '--host HOST',
@@ -63,7 +69,13 @@ class RedisKeysCheck < Sensu::Plugin::Check::CLI
          default: '*'
 
   def run
-    options = { host: config[:host], port: config[:port], db: config[:database] }
+    options = if config[:socket]
+                { path: socket }
+              else
+                { host: config[:host], port: config[:port] }
+              end
+
+    options[:db] = config[:database]
     options[:password] = config[:password] if config[:password]
     redis = Redis.new(options)
 

--- a/bin/check-redis-list-length.rb
+++ b/bin/check-redis-list-length.rb
@@ -15,6 +15,12 @@ require 'sensu-plugin/check/cli'
 require 'redis'
 
 class RedisListLengthCheck < Sensu::Plugin::Check::CLI
+  option :socket,
+         short: '-s SOCKET',
+         long: '--socket SOCKET',
+         description: 'Redis socket to connect to (overrides Host and Port)',
+         required: false
+
   option :host,
          short: '-h HOST',
          long: '--host HOST',
@@ -64,7 +70,13 @@ class RedisListLengthCheck < Sensu::Plugin::Check::CLI
          required: true
 
   def run
-    options = { host: config[:host], port: config[:port], db: config[:database] }
+    options = if config[:socket]
+                { path: socket }
+              else
+                { host: config[:host], port: config[:port] }
+              end
+
+    options[:db] = config[:database]
     options[:password] = config[:password] if config[:password]
     redis = Redis.new(options)
 

--- a/bin/check-redis-memory-percentage.rb
+++ b/bin/check-redis-memory-percentage.rb
@@ -30,6 +30,12 @@
 require 'sensu-plugin/check/cli'
 require 'redis'
 class RedisChecks < Sensu::Plugin::Check::CLI
+  option :socket,
+         short: '-s SOCKET',
+         long: '--socket SOCKET',
+         description: 'Redis socket to connect to (overrides Host and Port)',
+         required: false
+
   option :host,
          short: '-h HOST',
          long: '--host HOST',
@@ -75,7 +81,12 @@ class RedisChecks < Sensu::Plugin::Check::CLI
   end
 
   def run
-    options = { host: config[:host], port: config[:port] }
+    options = if config[:socket]
+                { path: socket }
+              else
+                { host: config[:host], port: config[:port] }
+              end
+
     options[:password] = config[:password] if config[:password]
     redis = Redis.new(options)
 

--- a/bin/check-redis-memory.rb
+++ b/bin/check-redis-memory.rb
@@ -12,6 +12,12 @@ require 'sensu-plugin/check/cli'
 require 'redis'
 
 class RedisChecks < Sensu::Plugin::Check::CLI
+  option :socket,
+         short: '-s SOCKET',
+         long: '--socket SOCKET',
+         description: 'Redis socket to connect to (overrides Host and Port)',
+         required: false
+
   option :host,
          short: '-h HOST',
          long: '--host HOST',
@@ -53,7 +59,12 @@ class RedisChecks < Sensu::Plugin::Check::CLI
          default: false
 
   def run
-    options = { host: config[:host], port: config[:port] }
+    options = if config[:socket]
+                { path: socket }
+              else
+                { host: config[:host], port: config[:port] }
+              end
+
     options[:password] = config[:password] if config[:password]
     redis = Redis.new(options)
 

--- a/bin/check-redis-ping.rb
+++ b/bin/check-redis-ping.rb
@@ -31,6 +31,12 @@ require 'sensu-plugin/check/cli'
 require 'redis'
 
 class RedisPing < Sensu::Plugin::Check::CLI
+  option :socket,
+         short: '-s SOCKET',
+         long: '--socket SOCKET',
+         description: 'Redis socket to connect to (overrides Host and Port)',
+         required: false
+
   option :host,
          short: '-h HOST',
          long: '--host HOST',
@@ -52,11 +58,18 @@ class RedisPing < Sensu::Plugin::Check::CLI
          description: 'Redis Password to connect with'
 
   def redis_options
-    {
-      host:     config[:host],
-      port:     config[:port],
-      password: config[:password]
-    }
+    if config[:socket]
+      {
+        path:     config[:socket],
+        password: config[:password]
+      }
+    else
+      {
+        host:     config[:host],
+        port:     config[:port],
+        password: config[:password]
+      }
+    end
   end
 
   def run

--- a/bin/check-redis-slave-status.rb
+++ b/bin/check-redis-slave-status.rb
@@ -6,6 +6,12 @@ require 'sensu-plugin/check/cli'
 require 'redis'
 
 class RedisSlaveCheck < Sensu::Plugin::Check::CLI
+  option :socket,
+         short: '-s SOCKET',
+         long: '--socket SOCKET',
+         description: 'Redis socket to connect to (overrides Host and Port)',
+         required: false
+
   option :host,
          short: '-h HOST',
          long: '--host HOST',
@@ -27,7 +33,12 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
          description: 'Redis Password to connect with'
 
   def run
-    options = { host: config[:host], port: config[:port] }
+    options = if config[:socket]
+                { path: socket }
+              else
+                { host: config[:host], port: config[:port] }
+              end
+
     options[:password] = config[:password] if config[:password]
     redis = Redis.new(options)
 

--- a/bin/metrics-redis-graphite.rb
+++ b/bin/metrics-redis-graphite.rb
@@ -47,6 +47,12 @@ class Redis2Graphite < Sensu::Plugin::Metric::CLI::Graphite
     'used_memory_rss_human'
   ].freeze
 
+  option :socket,
+         short: '-s SOCKET',
+         long: '--socket SOCKET',
+         description: 'Redis socket to connect to (overrides Host and Port)',
+         required: false
+
   option :host,
          short: '-h HOST',
          long: '--host HOST',
@@ -93,11 +99,17 @@ class Redis2Graphite < Sensu::Plugin::Metric::CLI::Graphite
 
   def run
     options = {
-      host: config[:host],
-      port: config[:port],
       timeout: config[:timeout],
       reconnect_attempts: config[:reconnect_attempts]
     }
+
+    if config[:socket]
+      options[:path] = config[:socket]
+    else
+      options[:host] = config[:host]
+      options[:port] = config[:port]
+    end
+
     options[:password] = config[:password] if config[:password]
     redis = Redis.new(options)
     skip_keys = if !config[:skip_keys_regex].nil?

--- a/bin/metrics-redis-llen.rb
+++ b/bin/metrics-redis-llen.rb
@@ -11,6 +11,12 @@ require 'sensu-plugin/metric/cli'
 require 'redis'
 
 class RedisListLengthMetric < Sensu::Plugin::Metric::CLI::Graphite
+  option :socket,
+         short: '-s SOCKET',
+         long: '--socket SOCKET',
+         description: 'Redis socket to connect to (overrides Host and Port)',
+         required: false
+
   option :host,
          short: '-h HOST',
          long: '--host HOST',
@@ -42,7 +48,12 @@ class RedisListLengthMetric < Sensu::Plugin::Metric::CLI::Graphite
          required: true
 
   def run
-    options = { host: config[:host], port: config[:port] }
+    options = if config[:socket]
+                { path: socket }
+              else
+                { host: config[:host], port: config[:port] }
+              end
+
     options[:password] = config[:password] if config[:password]
     redis = Redis.new(options)
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

Allow to connect to Redis servers via Unix sockets.

#### Known Compatablity Issues

All scripts should be unaffected, only when `--socket` option is used it takes precedence over `--host` and `--port` (this behavior follows `redis-cli`).
