### PR TITLE
metrics-redis-graphite: fix commandstats output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- metrics-redis-graphite, fix commandstats output (@boutetnico)
 
 ## [1.3.0] - 2017-05-31
 ### Added

--- a/bin/metrics-redis-graphite.rb
+++ b/bin/metrics-redis-graphite.rb
@@ -136,7 +136,7 @@ class Redis2Graphite < Sensu::Plugin::Metric::CLI::Graphite
 
     # Loop thru commandstats entries for perf metrics
     redis.info('commandstats').each do |k, v|
-      ['calls', 'usec_per_call', 'usec'].each do |x|
+      %w(calls usec_per_call usec).each do |x|
         output "#{config[:scheme]}.commandstats.#{k}.#{x}", v[x]
       end
     end

--- a/bin/metrics-redis-graphite.rb
+++ b/bin/metrics-redis-graphite.rb
@@ -136,7 +136,7 @@ class Redis2Graphite < Sensu::Plugin::Metric::CLI::Graphite
 
     # Loop thru commandstats entries for perf metrics
     redis.info('commandstats').each do |k, v|
-      %w(['calls', 'usec_per_call', 'usec']).each do |x|
+      ['calls', 'usec_per_call', 'usec'].each do |x|
         output "#{config[:scheme]}.commandstats.#{k}.#{x}", v[x]
       end
     end


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose

Fixes the output of the `commandstats` metrics introduced in #19.

Output before this fix:

```
redis01.redis.commandstats.command.['calls',
redis01.redis.commandstats.command.'usec_per_call',
redis01.redis.commandstats.command.'usec']
```

Output after the fix:

```
redis01.redis.commandstats.command.calls 3 1496217148
redis01.redis.commandstats.command.usec_per_call 1817.67 1496217148
redis01.redis.commandstats.command.usec 5453 1496217148
```

#### Known Compatablity Issues

