### PR TITLE
metrics-redis-graphite: fix skipkeys option not accepting any argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+## Fixed
+- metrics-redis-graphite: fix skipkeys option not accepting any argument (@boutetnico)
+
 ## [1.2.1] - 2017-05-14
 ## Fixed
 - Updated list of SKIP_KEYS_REGEX in metrics-redis-graphite.rb per #22 and added an option to override the list of keys to allow users to deal with changes without the need of a release (@majormoses)

--- a/bin/metrics-redis-graphite.rb
+++ b/bin/metrics-redis-graphite.rb
@@ -87,8 +87,8 @@ class Redis2Graphite < Sensu::Plugin::Metric::CLI::Graphite
 
   option :skip_keys_regex,
          description: 'a comma seperated list of keys to be skipped',
-         short: '-k',
-         long: '--skipkeys',
+         short: '-k KEYS',
+         long: '--skipkeys KEYS',
          default: nil
 
   def run


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

Fixes the `skipkeys` option that would not accept any argument (introduced in #31).

Output before this fix:

```
 $ /opt/sensu/embedded/bin/metrics-redis-graphite.rb -k role
Check failed to run: undefined method `split' for true:TrueClass, ["/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugins-redis-1.2.1/bin/metrics-redis-graphite.rb:104:in `run'", "/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugin-1.4.5/lib/sensu-plugin/cli.rb:58:in `block in <class:CLI>'"]
```

Output after the fix:

```
$ /opt/sensu/embedded/bin/metrics-redis-graphite.rb -k role | grep role
(empty result as expected)
```

#### Known Compatablity Issues

