### PR TITLE
Standardise exit statuses on connection failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Breaking Changes
+- Standardised exit status for Redis connection failures/timeouts to Unknown, with the exception of 'check-redis-ping' which will exit Critical
+
+### Added
+- Config option to override the default exit status on Redis connection failures/timeouts
+
 ### Added
 - ruby 2.4 testing on travis (@majormoses)
 

--- a/bin/check-redis-info.rb
+++ b/bin/check-redis-info.rb
@@ -60,6 +60,12 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
          required: false,
          default: 'master'
 
+  option :conn_failure_status,
+         long: '--conn-failure-status EXIT_STATUS',
+         description: 'Exit status for Redis connection failures',
+         default: 'unknown',
+         in: %w(unknown warning critical ok)
+
   def run
     options = if config[:socket]
                 { path: socket }
@@ -76,7 +82,6 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
       critical "Redis #{config[:redis_info_key]} is #{redis.info.fetch(config[:redis_info_key].to_s)}!"
     end
   rescue
-    message "Could not connect to Redis server on #{config[:host]}:#{config[:port]}"
-    exit 1
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{config[:host]}:#{config[:port]}")
   end
 end

--- a/bin/check-redis-info.rb
+++ b/bin/check-redis-info.rb
@@ -64,7 +64,7 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
          long: '--conn-failure-status EXIT_STATUS',
          description: 'Exit status for Redis connection failures',
          default: 'unknown',
-         in: %w(unknown warning critical ok)
+         in: %w(unknown warning critical)
 
   def run
     options = if config[:socket]

--- a/bin/check-redis-info.rb
+++ b/bin/check-redis-info.rb
@@ -62,7 +62,7 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
 
   option :conn_failure_status,
          long: '--conn-failure-status EXIT_STATUS',
-         description: 'Exit status for Redis connection failures',
+         description: 'Returns the following exit status for Redis connection failures',
          default: 'unknown',
          in: %w(unknown warning critical)
 

--- a/bin/check-redis-keys.rb
+++ b/bin/check-redis-keys.rb
@@ -72,7 +72,7 @@ class RedisKeysCheck < Sensu::Plugin::Check::CLI
          long: '--conn-failure-status EXIT_STATUS',
          description: 'Exit status for Redis connection failures',
          default: 'unknown',
-         in: %w(unknown warning critical ok)
+         in: %w(unknown warning critical)
 
   def run
     options = if config[:socket]

--- a/bin/check-redis-keys.rb
+++ b/bin/check-redis-keys.rb
@@ -70,7 +70,7 @@ class RedisKeysCheck < Sensu::Plugin::Check::CLI
 
   option :conn_failure_status,
          long: '--conn-failure-status EXIT_STATUS',
-         description: 'Exit status for Redis connection failures',
+         description: 'Returns the following exit status for Redis connection failures',
          default: 'unknown',
          in: %w(unknown warning critical)
 

--- a/bin/check-redis-keys.rb
+++ b/bin/check-redis-keys.rb
@@ -68,6 +68,12 @@ class RedisKeysCheck < Sensu::Plugin::Check::CLI
          required: false,
          default: '*'
 
+  option :conn_failure_status,
+         long: '--conn-failure-status EXIT_STATUS',
+         description: 'Exit status for Redis connection failures',
+         default: 'unknown',
+         in: %w(unknown warning critical ok)
+
   def run
     options = if config[:socket]
                 { path: socket }
@@ -89,6 +95,6 @@ class RedisKeysCheck < Sensu::Plugin::Check::CLI
       ok "Redis list #{config[:pattern]} length is above thresholds"
     end
   rescue
-    unknown "Could not connect to Redis server on #{config[:host]}:#{config[:port]}"
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{config[:host]}:#{config[:port]}")
   end
 end

--- a/bin/check-redis-list-length.rb
+++ b/bin/check-redis-list-length.rb
@@ -73,7 +73,7 @@ class RedisListLengthCheck < Sensu::Plugin::Check::CLI
          long: '--conn-failure-status EXIT_STATUS',
          description: 'Exit status for Redis connection failures',
          default: 'unknown',
-         in: %w(unknown warning critical ok)
+         in: %w(unknown warning critical)
 
   def run
     options = if config[:socket]

--- a/bin/check-redis-list-length.rb
+++ b/bin/check-redis-list-length.rb
@@ -71,7 +71,7 @@ class RedisListLengthCheck < Sensu::Plugin::Check::CLI
 
   option :conn_failure_status,
          long: '--conn-failure-status EXIT_STATUS',
-         description: 'Exit status for Redis connection failures',
+         description: 'Returns the following exit status for Redis connection failures',
          default: 'unknown',
          in: %w(unknown warning critical)
 

--- a/bin/check-redis-list-length.rb
+++ b/bin/check-redis-list-length.rb
@@ -69,6 +69,12 @@ class RedisListLengthCheck < Sensu::Plugin::Check::CLI
          description: 'Redis list KEY to check',
          required: true
 
+  option :conn_failure_status,
+         long: '--conn-failure-status EXIT_STATUS',
+         description: 'Exit status for Redis connection failures',
+         default: 'unknown',
+         in: %w(unknown warning critical ok)
+
   def run
     options = if config[:socket]
                 { path: socket }
@@ -97,6 +103,6 @@ class RedisListLengthCheck < Sensu::Plugin::Check::CLI
       ok "Redis list #{config[:key]} length (#{length}) is below thresholds"
     end
   rescue
-    unknown "Could not connect to Redis server on #{config[:host]}:#{config[:port]}"
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{config[:host]}:#{config[:port]}")
   end
 end

--- a/bin/check-redis-memory-percentage.rb
+++ b/bin/check-redis-memory-percentage.rb
@@ -80,7 +80,7 @@ class RedisChecks < Sensu::Plugin::Check::CLI
          long: '--conn-failure-status EXIT_STATUS',
          description: 'Exit status for Redis connection failures',
          default: 'unknown',
-         in: %w(unknown warning critical ok)
+         in: %w(unknown warning critical)
 
   def system_memory
     `awk '/MemTotal/{print$2}' /proc/meminfo`.to_f * 1024

--- a/bin/check-redis-memory-percentage.rb
+++ b/bin/check-redis-memory-percentage.rb
@@ -76,6 +76,12 @@ class RedisChecks < Sensu::Plugin::Check::CLI
          description: 'Critical instead of warning on connection failure',
          default: false
 
+  option :conn_failure_status,
+         long: '--conn-failure-status EXIT_STATUS',
+         description: 'Exit status for Redis connection failures',
+         default: 'unknown',
+         in: %w(unknown warning critical ok)
+
   def system_memory
     `awk '/MemTotal/{print$2}' /proc/meminfo`.to_f * 1024
   end
@@ -109,11 +115,6 @@ class RedisChecks < Sensu::Plugin::Check::CLI
       ok "Redis memory usage: #{used_memory}% is below defined limits"
     end
   rescue
-    message = "Could not connect to Redis server on #{config[:host]}:#{config[:port]}"
-    if config[:crit_conn]
-      critical message
-    else
-      warning message
-    end
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{config[:host]}:#{config[:port]}")
   end
 end

--- a/bin/check-redis-memory-percentage.rb
+++ b/bin/check-redis-memory-percentage.rb
@@ -70,15 +70,9 @@ class RedisChecks < Sensu::Plugin::Check::CLI
          proc: proc(&:to_i),
          required: true
 
-  option :crit_conn,
-         long: '--crit-conn-failure',
-         boolean: true,
-         description: 'Critical instead of warning on connection failure',
-         default: false
-
   option :conn_failure_status,
          long: '--conn-failure-status EXIT_STATUS',
-         description: 'Exit status for Redis connection failures',
+         description: 'Returns the following exit status for Redis connection failures',
          default: 'unknown',
          in: %w(unknown warning critical)
 

--- a/bin/check-redis-memory.rb
+++ b/bin/check-redis-memory.rb
@@ -58,6 +58,12 @@ class RedisChecks < Sensu::Plugin::Check::CLI
          description: 'Critical instead of warning on connection failure',
          default: false
 
+  option :conn_failure_status,
+         long: '--conn-failure-status EXIT_STATUS',
+         description: 'Exit status for Redis connection failures',
+         default: 'unknown',
+         in: %w(unknown warning critical ok)
+
   def run
     options = if config[:socket]
                 { path: socket }
@@ -79,11 +85,6 @@ class RedisChecks < Sensu::Plugin::Check::CLI
       ok "Redis memory usage: #{used_memory}KB is below defined limits"
     end
   rescue
-    message = "Could not connect to Redis server on #{config[:host]}:#{config[:port]}"
-    if config[:crit_conn]
-      critical message
-    else
-      warning message
-    end
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{config[:host]}:#{config[:port]}")
   end
 end

--- a/bin/check-redis-memory.rb
+++ b/bin/check-redis-memory.rb
@@ -52,15 +52,9 @@ class RedisChecks < Sensu::Plugin::Check::CLI
          proc: proc(&:to_i),
          required: true
 
-  option :crit_conn,
-         long: '--crit-conn-failure',
-         boolean: true,
-         description: 'Critical instead of warning on connection failure',
-         default: false
-
   option :conn_failure_status,
          long: '--conn-failure-status EXIT_STATUS',
-         description: 'Exit status for Redis connection failures',
+         description: 'Returns the following exit status for Redis connection failures',
          default: 'unknown',
          in: %w(unknown warning critical)
 

--- a/bin/check-redis-memory.rb
+++ b/bin/check-redis-memory.rb
@@ -62,7 +62,7 @@ class RedisChecks < Sensu::Plugin::Check::CLI
          long: '--conn-failure-status EXIT_STATUS',
          description: 'Exit status for Redis connection failures',
          default: 'unknown',
-         in: %w(unknown warning critical ok)
+         in: %w(unknown warning critical)
 
   def run
     options = if config[:socket]

--- a/bin/check-redis-ping.rb
+++ b/bin/check-redis-ping.rb
@@ -59,7 +59,7 @@ class RedisPing < Sensu::Plugin::Check::CLI
 
   option :conn_failure_status,
          long: '--conn-failure-status EXIT_STATUS',
-         description: 'Exit status for Redis connection failures',
+         description: 'Returns the following exit status for Redis connection failures',
          default: 'critical',
          in: %w(unknown warning critical)
 

--- a/bin/check-redis-ping.rb
+++ b/bin/check-redis-ping.rb
@@ -61,7 +61,7 @@ class RedisPing < Sensu::Plugin::Check::CLI
          long: '--conn-failure-status EXIT_STATUS',
          description: 'Exit status for Redis connection failures',
          default: 'critical',
-         in: %w(unknown warning critical ok)
+         in: %w(unknown warning critical)
 
   def redis_options
     if config[:socket]

--- a/bin/check-redis-ping.rb
+++ b/bin/check-redis-ping.rb
@@ -57,6 +57,12 @@ class RedisPing < Sensu::Plugin::Check::CLI
          long: '--password PASSWORD',
          description: 'Redis Password to connect with'
 
+  option :conn_failure_status,
+         long: '--conn-failure-status EXIT_STATUS',
+         description: 'Exit status for Redis connection failures',
+         default: 'critical',
+         in: %w(unknown warning critical ok)
+
   def redis_options
     if config[:socket]
       {
@@ -78,9 +84,7 @@ class RedisPing < Sensu::Plugin::Check::CLI
     else
       critical 'Redis did not respond to the ping command'
     end
-
   rescue
-    message "Could not connect to Redis server on #{config[:host]}:#{config[:port]}"
-    exit 1
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{config[:host]}:#{config[:port]}")
   end
 end

--- a/bin/check-redis-slave-status.rb
+++ b/bin/check-redis-slave-status.rb
@@ -32,6 +32,12 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
          long: '--password PASSWORD',
          description: 'Redis Password to connect with'
 
+  option :conn_failure_status,
+         long: '--conn-failure-status EXIT_STATUS',
+         description: 'Exit status for Redis connection failures',
+         default: 'unknown',
+         in: %w(unknown warning critical ok)
+
   def run
     options = if config[:socket]
                 { path: socket }
@@ -52,11 +58,9 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
       msg += " It has been down for #{redis.info.fetch('master_link_down_since_seconds')}."
       critical msg
     end
-
   rescue KeyError
     critical "Redis server on #{config[:host]}:#{config[:port]} is not master and does not have master_link_status"
-
   rescue
-    critical "Could not connect to Redis server on #{config[:host]}:#{config[:port]}"
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{config[:host]}:#{config[:port]}")
   end
 end

--- a/bin/check-redis-slave-status.rb
+++ b/bin/check-redis-slave-status.rb
@@ -36,7 +36,7 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
          long: '--conn-failure-status EXIT_STATUS',
          description: 'Exit status for Redis connection failures',
          default: 'unknown',
-         in: %w(unknown warning critical ok)
+         in: %w(unknown warning critical)
 
   def run
     options = if config[:socket]

--- a/bin/check-redis-slave-status.rb
+++ b/bin/check-redis-slave-status.rb
@@ -34,7 +34,7 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
 
   option :conn_failure_status,
          long: '--conn-failure-status EXIT_STATUS',
-         description: 'Exit status for Redis connection failures',
+         description: 'Returns the following exit status for Redis connection failures',
          default: 'unknown',
          in: %w(unknown warning critical)
 

--- a/bin/metrics-redis-graphite.rb
+++ b/bin/metrics-redis-graphite.rb
@@ -99,7 +99,7 @@ class Redis2Graphite < Sensu::Plugin::Metric::CLI::Graphite
 
   option :conn_failure_status,
          long: '--conn-failure-status EXIT_STATUS',
-         description: 'Exit status for Redis connection failures',
+         description: 'Returns the following exit status for Redis connection failures',
          default: 'unknown',
          in: %w(unknown warning critical)
 

--- a/bin/metrics-redis-graphite.rb
+++ b/bin/metrics-redis-graphite.rb
@@ -101,7 +101,7 @@ class Redis2Graphite < Sensu::Plugin::Metric::CLI::Graphite
          long: '--conn-failure-status EXIT_STATUS',
          description: 'Exit status for Redis connection failures',
          default: 'unknown',
-         in: %w(unknown warning critical ok)
+         in: %w(unknown warning critical)
 
   def run
     options = {

--- a/bin/metrics-redis-graphite.rb
+++ b/bin/metrics-redis-graphite.rb
@@ -97,6 +97,12 @@ class Redis2Graphite < Sensu::Plugin::Metric::CLI::Graphite
          long: '--skipkeys KEYS',
          default: nil
 
+  option :conn_failure_status,
+         long: '--conn-failure-status EXIT_STATUS',
+         description: 'Exit status for Redis connection failures',
+         default: 'unknown',
+         in: %w(unknown warning critical ok)
+
   def run
     options = {
       timeout: config[:timeout],
@@ -142,5 +148,7 @@ class Redis2Graphite < Sensu::Plugin::Metric::CLI::Graphite
     end
 
     ok
+  rescue
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{config[:host]}:#{config[:port]}")
   end
 end

--- a/bin/metrics-redis-llen.rb
+++ b/bin/metrics-redis-llen.rb
@@ -51,7 +51,7 @@ class RedisListLengthMetric < Sensu::Plugin::Metric::CLI::Graphite
          long: '--conn-failure-status EXIT_STATUS',
          description: 'Exit status for Redis connection failures',
          default: 'unknown',
-         in: %w(unknown warning critical ok)
+         in: %w(unknown warning critical)
 
   def run
     options = if config[:socket]

--- a/bin/metrics-redis-llen.rb
+++ b/bin/metrics-redis-llen.rb
@@ -47,6 +47,12 @@ class RedisListLengthMetric < Sensu::Plugin::Metric::CLI::Graphite
          description: 'Redis list KEY to check',
          required: true
 
+  option :conn_failure_status,
+         long: '--conn-failure-status EXIT_STATUS',
+         description: 'Exit status for Redis connection failures',
+         default: 'unknown',
+         in: %w(unknown warning critical ok)
+
   def run
     options = if config[:socket]
                 { path: socket }
@@ -59,5 +65,7 @@ class RedisListLengthMetric < Sensu::Plugin::Metric::CLI::Graphite
 
     output "#{config[:scheme]}.#{config[:key]}.items", redis.llen(config[:key])
     ok
+  rescue
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{config[:host]}:#{config[:port]}")
   end
 end

--- a/bin/metrics-redis-llen.rb
+++ b/bin/metrics-redis-llen.rb
@@ -49,7 +49,7 @@ class RedisListLengthMetric < Sensu::Plugin::Metric::CLI::Graphite
 
   option :conn_failure_status,
          long: '--conn-failure-status EXIT_STATUS',
-         description: 'Exit status for Redis connection failures',
+         description: 'Returns the following exit status for Redis connection failures',
          default: 'unknown',
          in: %w(unknown warning critical)
 

--- a/test/check-redis-ping_spec.rb
+++ b/test/check-redis-ping_spec.rb
@@ -1,0 +1,21 @@
+require_relative './spec_helper.rb'
+require_relative '../bin/check-redis-ping.rb'
+
+describe 'CheckRedisPing', '#run' do
+  before(:all) do
+    RedisPing.class_variable_set(:@@autorun, nil)
+  end
+
+  it 'accepts config' do
+    args = %w(--host 127.0.0.1 --password foobar)
+    check = RedisPing.new(args)
+    expect(check.config[:password]).to eq 'foobar'
+  end
+
+  it 'returns warning' do
+    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning)
+    check = RedisPing.new(args)
+    expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

RE https://github.com/sensu-plugins/sensu-plugins-redis/issues/39, https://github.com/sensu-plugins/sensu-plugins-redis/pull/5

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

As per linked issue, there is currently a lack of consistency in how redis checks handle connection timeouts. Existing checks are using different exit statuses, and only some provide the option to change this exit value.

This change sets the default exit status on redis failures to unknown, with the exception of `check-redis-ping.rb` which will exit critical (As the nature of that check is to ensure redis can be connected to). It also provides a config option on all checks to alter this.

Wasn't too sure around tests to add, so just kept one that confirms the functionality of the change.

#### Known Compatibility Issues

This will be a breaking change for existing users as exit codes will change.
