### PR TITLE
Rename metrics scheme short option to resolve conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- metrics-redis-graphite.rb, metrics-redis-llen.rb: rename short option for `--scheme` from `-s` to `-S` to resolve conflict.
 
 ## [2.0.0] - 2017-07-23
 ### Breaking Changes

--- a/bin/metrics-redis-graphite.rb
+++ b/bin/metrics-redis-graphite.rb
@@ -73,7 +73,7 @@ class Redis2Graphite < Sensu::Plugin::Metric::CLI::Graphite
 
   option :scheme,
          description: 'Metric naming scheme, text to prepend to metric',
-         short: '-s SCHEME',
+         short: '-S SCHEME',
          long: '--scheme SCHEME',
          default: "#{Socket.gethostname}.redis"
 

--- a/bin/metrics-redis-llen.rb
+++ b/bin/metrics-redis-llen.rb
@@ -37,7 +37,7 @@ class RedisListLengthMetric < Sensu::Plugin::Metric::CLI::Graphite
 
   option :scheme,
          description: 'Metric naming scheme, text to prepend to metric',
-         short: '-s SCHEME',
+         short: '-S SCHEME',
          long: '--scheme SCHEME',
          default: "#{Socket.gethostname}.redis"
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
#41 
#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
The `-s` short option for `--scheme` is currently unreachable, as it's superseded by `-s` for `--socket`.

#### Known Compatibility Issues
None.
