### PR TITLE
Feature/add timeout option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Added
+- All check files have timeout added (@empyrean987)
+
 ## [2.1.0] - 2017-08-17
 ### Added
 - metrics-redis-llen.rb config option to choose db (@athal7)

--- a/bin/check-redis-info.rb
+++ b/bin/check-redis-info.rb
@@ -70,6 +70,7 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
          short: '-t TIMEOUT',
          long: '--timeout TIMEOUT',
          description: 'Redis connection timeout',
+         proc: proc(&:to_i),
          required: false,
          default: 5
 

--- a/bin/check-redis-info.rb
+++ b/bin/check-redis-info.rb
@@ -65,12 +65,19 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
          description: 'Returns the following exit status for Redis connection failures',
          default: 'unknown',
          in: %w(unknown warning critical)
+         
+  option :timeout,
+         short: '-t TIMEOUT',
+         long: '--timeout TIMEOUT',
+         description: 'Redis connection timeout',
+         required: false,
+         default: 5 
 
   def run
     options = if config[:socket]
                 { path: socket }
               else
-                { host: config[:host], port: config[:port] }
+                { host: config[:host], port: config[:port], timeout: config[:timeout] }
               end
 
     options[:password] = config[:password] if config[:password]

--- a/bin/check-redis-info.rb
+++ b/bin/check-redis-info.rb
@@ -65,13 +65,13 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
          description: 'Returns the following exit status for Redis connection failures',
          default: 'unknown',
          in: %w(unknown warning critical)
-         
+
   option :timeout,
          short: '-t TIMEOUT',
          long: '--timeout TIMEOUT',
          description: 'Redis connection timeout',
          required: false,
-         default: 5 
+         default: 5
 
   def run
     options = if config[:socket]

--- a/bin/check-redis-keys.rb
+++ b/bin/check-redis-keys.rb
@@ -78,6 +78,7 @@ class RedisKeysCheck < Sensu::Plugin::Check::CLI
          short: '-t TIMEOUT',
          long: '--timeout TIMEOUT',
          description: 'Redis connection timeout',
+         proc: proc(&:to_i),
          required: false,
          default: 5
 

--- a/bin/check-redis-keys.rb
+++ b/bin/check-redis-keys.rb
@@ -79,7 +79,7 @@ class RedisKeysCheck < Sensu::Plugin::Check::CLI
          long: '--timeout TIMEOUT',
          description: 'Redis connection timeout',
          required: false,
-         default: 5 
+         default: 5
 
   def run
     options = if config[:socket]

--- a/bin/check-redis-keys.rb
+++ b/bin/check-redis-keys.rb
@@ -74,11 +74,18 @@ class RedisKeysCheck < Sensu::Plugin::Check::CLI
          default: 'unknown',
          in: %w(unknown warning critical)
 
+  option :timeout,
+         short: '-t TIMEOUT',
+         long: '--timeout TIMEOUT',
+         description: 'Redis connection timeout',
+         required: false,
+         default: 5 
+
   def run
     options = if config[:socket]
                 { path: socket }
               else
-                { host: config[:host], port: config[:port] }
+                { host: config[:host], port: config[:port], timeout: config[:timeout] }
               end
 
     options[:db] = config[:database]

--- a/bin/check-redis-list-length.rb
+++ b/bin/check-redis-list-length.rb
@@ -80,7 +80,7 @@ class RedisListLengthCheck < Sensu::Plugin::Check::CLI
          long: '--timeout TIMEOUT',
          description: 'Redis connection timeout',
          required: false,
-         default: 5 
+         default: 5
 
   def run
     options = if config[:socket]

--- a/bin/check-redis-list-length.rb
+++ b/bin/check-redis-list-length.rb
@@ -79,6 +79,7 @@ class RedisListLengthCheck < Sensu::Plugin::Check::CLI
          short: '-t TIMEOUT',
          long: '--timeout TIMEOUT',
          description: 'Redis connection timeout',
+         proc: proc(&:to_i),
          required: false,
          default: 5
 

--- a/bin/check-redis-list-length.rb
+++ b/bin/check-redis-list-length.rb
@@ -75,11 +75,18 @@ class RedisListLengthCheck < Sensu::Plugin::Check::CLI
          default: 'unknown',
          in: %w(unknown warning critical)
 
+  option :timeout,
+         short: '-t TIMEOUT',
+         long: '--timeout TIMEOUT',
+         description: 'Redis connection timeout',
+         required: false,
+         default: 5 
+
   def run
     options = if config[:socket]
                 { path: config[:socket] }
               else
-                { host: config[:host], port: config[:port] }
+                { host: config[:host], port: config[:port], timeout: config[:timeout] }
               end
 
     options[:db] = config[:database]

--- a/bin/check-redis-memory-percentage.rb
+++ b/bin/check-redis-memory-percentage.rb
@@ -80,6 +80,7 @@ class RedisChecks < Sensu::Plugin::Check::CLI
          short: '-t TIMEOUT',
          long: '--timeout TIMEOUT',
          description: 'Redis connection timeout',
+         proc: proc(&:to_i),
          required: false,
          default: 5
 

--- a/bin/check-redis-memory-percentage.rb
+++ b/bin/check-redis-memory-percentage.rb
@@ -76,6 +76,13 @@ class RedisChecks < Sensu::Plugin::Check::CLI
          default: 'unknown',
          in: %w(unknown warning critical)
 
+  option :timeout,
+         short: '-t TIMEOUT',
+         long: '--timeout TIMEOUT',
+         description: 'Redis connection timeout',
+         required: false,
+         default: 5 
+
   def system_memory
     `awk '/MemTotal/{print$2}' /proc/meminfo`.to_f * 1024
   end
@@ -84,7 +91,7 @@ class RedisChecks < Sensu::Plugin::Check::CLI
     options = if config[:socket]
                 { path: socket }
               else
-                { host: config[:host], port: config[:port] }
+                { host: config[:host], port: config[:port], timeout: config[:timeout] }
               end
 
     options[:password] = config[:password] if config[:password]

--- a/bin/check-redis-memory-percentage.rb
+++ b/bin/check-redis-memory-percentage.rb
@@ -81,7 +81,7 @@ class RedisChecks < Sensu::Plugin::Check::CLI
          long: '--timeout TIMEOUT',
          description: 'Redis connection timeout',
          required: false,
-         default: 5 
+         default: 5
 
   def system_memory
     `awk '/MemTotal/{print$2}' /proc/meminfo`.to_f * 1024

--- a/bin/check-redis-memory.rb
+++ b/bin/check-redis-memory.rb
@@ -58,11 +58,18 @@ class RedisChecks < Sensu::Plugin::Check::CLI
          default: 'unknown',
          in: %w(unknown warning critical)
 
+  option :timeout,
+         short: '-t TIMEOUT',
+         long: '--timeout TIMEOUT',
+         description: 'Redis connection timeout',
+         required: false,
+         default: 5 
+
   def run
     options = if config[:socket]
                 { path: socket }
               else
-                { host: config[:host], port: config[:port] }
+                { host: config[:host], port: config[:port], timeout: config[:timeout] }
               end
 
     options[:password] = config[:password] if config[:password]

--- a/bin/check-redis-memory.rb
+++ b/bin/check-redis-memory.rb
@@ -63,7 +63,7 @@ class RedisChecks < Sensu::Plugin::Check::CLI
          long: '--timeout TIMEOUT',
          description: 'Redis connection timeout',
          required: false,
-         default: 5 
+         default: 5
 
   def run
     options = if config[:socket]

--- a/bin/check-redis-memory.rb
+++ b/bin/check-redis-memory.rb
@@ -62,6 +62,7 @@ class RedisChecks < Sensu::Plugin::Check::CLI
          short: '-t TIMEOUT',
          long: '--timeout TIMEOUT',
          description: 'Redis connection timeout',
+         proc: proc(&:to_i),
          required: false,
          default: 5
 

--- a/bin/check-redis-ping.rb
+++ b/bin/check-redis-ping.rb
@@ -67,6 +67,7 @@ class RedisPing < Sensu::Plugin::Check::CLI
          short: '-t TIMEOUT',
          long: '--timeout TIMEOUT',
          description: 'Redis connection timeout',
+         proc: proc(&:to_i),
          required: false,
          default: 5
 

--- a/bin/check-redis-ping.rb
+++ b/bin/check-redis-ping.rb
@@ -63,6 +63,13 @@ class RedisPing < Sensu::Plugin::Check::CLI
          default: 'critical',
          in: %w(unknown warning critical)
 
+  option :timeout,
+         short: '-t TIMEOUT',
+         long: '--timeout TIMEOUT',
+         description: 'Redis connection timeout',
+         required: false,
+         default: 5 
+
   def redis_options
     if config[:socket]
       {
@@ -73,7 +80,8 @@ class RedisPing < Sensu::Plugin::Check::CLI
       {
         host:     config[:host],
         port:     config[:port],
-        password: config[:password]
+        password: config[:password],
+        timeout:  config[:timeout] 
       }
     end
   end

--- a/bin/check-redis-ping.rb
+++ b/bin/check-redis-ping.rb
@@ -68,7 +68,7 @@ class RedisPing < Sensu::Plugin::Check::CLI
          long: '--timeout TIMEOUT',
          description: 'Redis connection timeout',
          required: false,
-         default: 5 
+         default: 5
 
   def redis_options
     if config[:socket]
@@ -81,7 +81,7 @@ class RedisPing < Sensu::Plugin::Check::CLI
         host:     config[:host],
         port:     config[:port],
         password: config[:password],
-        timeout:  config[:timeout] 
+        timeout:  config[:timeout]
       }
     end
   end

--- a/bin/check-redis-slave-status.rb
+++ b/bin/check-redis-slave-status.rb
@@ -43,7 +43,7 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
          long: '--timeout TIMEOUT',
          description: 'Redis connection timeout',
          required: false,
-         default: 5 
+         default: 5
 
   def run
     options = if config[:socket]

--- a/bin/check-redis-slave-status.rb
+++ b/bin/check-redis-slave-status.rb
@@ -38,11 +38,18 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
          default: 'unknown',
          in: %w(unknown warning critical)
 
+  option :timeout,
+         short: '-t TIMEOUT',
+         long: '--timeout TIMEOUT',
+         description: 'Redis connection timeout',
+         required: false,
+         default: 5 
+
   def run
     options = if config[:socket]
                 { path: socket }
               else
-                { host: config[:host], port: config[:port] }
+                { host: config[:host], port: config[:port], timeout: config[:timeout] }
               end
 
     options[:password] = config[:password] if config[:password]

--- a/bin/check-redis-slave-status.rb
+++ b/bin/check-redis-slave-status.rb
@@ -43,6 +43,7 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
          long: '--timeout TIMEOUT',
          description: 'Redis connection timeout',
          required: false,
+         proc: proc(&:to_i),
          default: 5
 
   def run


### PR DESCRIPTION
Found an issue with the version of ruby I tested with, need to convert timeout to integer when using external variables.