### PR TITLE
Ensure that every script can access Redis via Unix socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines ](https://
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- ensure that `--socket` option is properly parsed and takes precedence over `--host`/`--port` (@mbyczkowski)
 
 ## [2.3.0] - 2017-11-12
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 ## Files
  * bin/check-redis-info.rb
+ * bin/check-redis-keys.rb
  * bin/check-redis-list-length.rb
  * bin/check-redis-memory.rb
  * bin/check-redis-memory-percentage.rb
@@ -25,3 +26,6 @@
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)
 
 ## Notes
+
+[Developer Guidelines](http://sensu-plugins.io/docs/developer_guidelines.html)
+[Testing](http://sensu-plugins.io/docs/testing.html)

--- a/Rakefile
+++ b/Rakefile
@@ -36,6 +36,11 @@ task :check_binstubs do
   end
 end
 
+desc 'Run unit tests only'
+RSpec::Core::RakeTask.new(:unit) do |r|
+  r.pattern = FileList['**/**/*_spec.rb'].exclude(/test\/integration\//)
+end
+
 Kitchen::RakeTasks.new
 
 desc 'Alias for kitchen:all'
@@ -54,4 +59,4 @@ end
 
 task default: %i(make_bin_executable yard rubocop check_binstubs integration)
 
-task quick: %i(make_bin_executable yard rubocop check_binstubs)
+task quick: %i(make_bin_executable yard rubocop check_binstubs unit)

--- a/bin/check-redis-info.rb
+++ b/bin/check-redis-info.rb
@@ -46,6 +46,6 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
       critical "Redis #{config[:redis_info_key]} is #{redis.info.fetch(config[:redis_info_key].to_s)}!"
     end
   rescue
-    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_conn_info}")
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/bin/check-redis-info.rb
+++ b/bin/check-redis-info.rb
@@ -18,33 +18,10 @@
 
 require 'sensu-plugin/check/cli'
 require 'redis'
+require_relative '../lib/redis_client_options'
 
 class RedisSlaveCheck < Sensu::Plugin::Check::CLI
-  option :socket,
-         short: '-s SOCKET',
-         long: '--socket SOCKET',
-         description: 'Redis socket to connect to (overrides Host and Port)',
-         required: false
-
-  option :host,
-         short: '-h HOST',
-         long: '--host HOST',
-         description: 'Redis Host to connect to',
-         required: false,
-         default: '127.0.0.1'
-
-  option :port,
-         short: '-p PORT',
-         long: '--port PORT',
-         description: 'Redis Port to connect to',
-         proc: proc(&:to_i),
-         required: false,
-         default: 6379
-
-  option :password,
-         short: '-P PASSWORD',
-         long: '--password PASSWORD',
-         description: 'Redis Password to connect with'
+  include RedisClientOptions
 
   option :redis_info_key,
          short: '-K VALUE',
@@ -60,29 +37,8 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
          required: false,
          default: 'master'
 
-  option :conn_failure_status,
-         long: '--conn-failure-status EXIT_STATUS',
-         description: 'Returns the following exit status for Redis connection failures',
-         default: 'unknown',
-         in: %w(unknown warning critical)
-
-  option :timeout,
-         short: '-t TIMEOUT',
-         long: '--timeout TIMEOUT',
-         description: 'Redis connection timeout',
-         proc: proc(&:to_i),
-         required: false,
-         default: 5
-
   def run
-    options = if config[:socket]
-                { path: socket }
-              else
-                { host: config[:host], port: config[:port], timeout: config[:timeout] }
-              end
-
-    options[:password] = config[:password] if config[:password]
-    redis = Redis.new(options)
+    redis = Redis.new(default_redis_options)
 
     if redis.info.fetch(config[:redis_info_key].to_s) == config[:redis_info_value].to_s
       ok "Redis #{config[:redis_info_key]} is #{config[:redis_info_value]}"
@@ -90,6 +46,6 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
       critical "Redis #{config[:redis_info_key]} is #{redis.info.fetch(config[:redis_info_key].to_s)}!"
     end
   rescue
-    send(config[:conn_failure_status], "Could not connect to Redis server on #{config[:host]}:#{config[:port]}")
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_conn_info}")
   end
 end

--- a/bin/check-redis-keys.rb
+++ b/bin/check-redis-keys.rb
@@ -12,41 +12,10 @@
 
 require 'sensu-plugin/check/cli'
 require 'redis'
+require_relative '../lib/redis_client_options'
 
 class RedisKeysCheck < Sensu::Plugin::Check::CLI
-  option :socket,
-         short: '-s SOCKET',
-         long: '--socket SOCKET',
-         description: 'Redis socket to connect to (overrides Host and Port)',
-         required: false
-
-  option :host,
-         short: '-h HOST',
-         long: '--host HOST',
-         description: 'Redis Host to connect to',
-         required: false,
-         default: '127.0.0.1'
-
-  option :port,
-         short: '-p PORT',
-         long: '--port PORT',
-         description: 'Redis Port to connect to',
-         proc: proc(&:to_i),
-         required: false,
-         default: 6379
-
-  option :database,
-         short: '-n DATABASE',
-         long: '--dbnumber DATABASE',
-         description: 'Redis database number to connect to',
-         proc: proc(&:to_i),
-         required: false,
-         default: 0
-
-  option :password,
-         short: '-P PASSWORD',
-         long: '--password PASSWORD',
-         description: 'Redis Password to connect with'
+  include RedisClientOptions
 
   option :warn,
          short: '-w COUNT',
@@ -68,30 +37,8 @@ class RedisKeysCheck < Sensu::Plugin::Check::CLI
          required: false,
          default: '*'
 
-  option :conn_failure_status,
-         long: '--conn-failure-status EXIT_STATUS',
-         description: 'Returns the following exit status for Redis connection failures',
-         default: 'unknown',
-         in: %w(unknown warning critical)
-
-  option :timeout,
-         short: '-t TIMEOUT',
-         long: '--timeout TIMEOUT',
-         description: 'Redis connection timeout',
-         proc: proc(&:to_i),
-         required: false,
-         default: 5
-
   def run
-    options = if config[:socket]
-                { path: socket }
-              else
-                { host: config[:host], port: config[:port], timeout: config[:timeout] }
-              end
-
-    options[:db] = config[:database]
-    options[:password] = config[:password] if config[:password]
-    redis = Redis.new(options)
+    redis = Redis.new(default_redis_options)
 
     length = redis.keys(config[:pattern]).size
 
@@ -103,6 +50,6 @@ class RedisKeysCheck < Sensu::Plugin::Check::CLI
       ok "Redis list #{config[:pattern]} length is above thresholds"
     end
   rescue
-    send(config[:conn_failure_status], "Could not connect to Redis server on #{config[:host]}:#{config[:port]}")
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_conn_info}")
   end
 end

--- a/bin/check-redis-keys.rb
+++ b/bin/check-redis-keys.rb
@@ -50,6 +50,6 @@ class RedisKeysCheck < Sensu::Plugin::Check::CLI
       ok "Redis list #{config[:pattern]} length is above thresholds"
     end
   rescue
-    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_conn_info}")
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/bin/check-redis-list-length.rb
+++ b/bin/check-redis-list-length.rb
@@ -58,6 +58,6 @@ class RedisListLengthCheck < Sensu::Plugin::Check::CLI
       ok "Redis list #{config[:key]} length (#{length}) is below thresholds"
     end
   rescue
-    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_conn_info}")
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/bin/check-redis-memory-percentage.rb
+++ b/bin/check-redis-memory-percentage.rb
@@ -29,32 +29,10 @@
 
 require 'sensu-plugin/check/cli'
 require 'redis'
+require_relative '../lib/redis_client_options'
+
 class RedisChecks < Sensu::Plugin::Check::CLI
-  option :socket,
-         short: '-s SOCKET',
-         long: '--socket SOCKET',
-         description: 'Redis socket to connect to (overrides Host and Port)',
-         required: false
-
-  option :host,
-         short: '-h HOST',
-         long: '--host HOST',
-         description: 'Redis Host to connect to',
-         required: false,
-         default: '127.0.0.1'
-
-  option :port,
-         short: '-p PORT',
-         long: '--port PORT',
-         description: 'Redis Port to connect to',
-         proc: proc(&:to_i),
-         required: false,
-         default: 6379
-
-  option :password,
-         short: '-P PASSWORD',
-         long: '--password PASSWORD',
-         description: 'Redis Password to connect with'
+  include RedisClientOptions
 
   option :warn_mem,
          short: '-w percentage',
@@ -70,33 +48,12 @@ class RedisChecks < Sensu::Plugin::Check::CLI
          proc: proc(&:to_i),
          required: true
 
-  option :conn_failure_status,
-         long: '--conn-failure-status EXIT_STATUS',
-         description: 'Returns the following exit status for Redis connection failures',
-         default: 'unknown',
-         in: %w(unknown warning critical)
-
-  option :timeout,
-         short: '-t TIMEOUT',
-         long: '--timeout TIMEOUT',
-         description: 'Redis connection timeout',
-         proc: proc(&:to_i),
-         required: false,
-         default: 5
-
   def system_memory
     `awk '/MemTotal/{print$2}' /proc/meminfo`.to_f * 1024
   end
 
   def run
-    options = if config[:socket]
-                { path: socket }
-              else
-                { host: config[:host], port: config[:port], timeout: config[:timeout] }
-              end
-
-    options[:password] = config[:password] if config[:password]
-    redis = Redis.new(options)
+    redis = Redis.new(default_redis_options)
 
     redis_info = redis.info
     max_memory = redis_info.fetch('maxmemory', 0).to_i
@@ -117,6 +74,6 @@ class RedisChecks < Sensu::Plugin::Check::CLI
       ok "Redis memory usage: #{used_memory}% is below defined limits"
     end
   rescue
-    send(config[:conn_failure_status], "Could not connect to Redis server on #{config[:host]}:#{config[:port]}")
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_conn_info}")
   end
 end

--- a/bin/check-redis-memory-percentage.rb
+++ b/bin/check-redis-memory-percentage.rb
@@ -74,6 +74,6 @@ class RedisChecks < Sensu::Plugin::Check::CLI
       ok "Redis memory usage: #{used_memory}% is below defined limits"
     end
   rescue
-    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_conn_info}")
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/bin/check-redis-memory.rb
+++ b/bin/check-redis-memory.rb
@@ -43,6 +43,6 @@ class RedisChecks < Sensu::Plugin::Check::CLI
       ok "Redis memory usage: #{used_memory}KB is below defined limits"
     end
   rescue
-    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_conn_info}")
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/bin/check-redis-ping.rb
+++ b/bin/check-redis-ping.rb
@@ -41,6 +41,6 @@ class RedisPing < Sensu::Plugin::Check::CLI
       critical 'Redis did not respond to the ping command'
     end
   rescue
-    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_conn_info}")
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/bin/check-redis-ping.rb
+++ b/bin/check-redis-ping.rb
@@ -29,71 +29,18 @@
 
 require 'sensu-plugin/check/cli'
 require 'redis'
+require_relative '../lib/redis_client_options'
 
 class RedisPing < Sensu::Plugin::Check::CLI
-  option :socket,
-         short: '-s SOCKET',
-         long: '--socket SOCKET',
-         description: 'Redis socket to connect to (overrides Host and Port)',
-         required: false
-
-  option :host,
-         short: '-h HOST',
-         long: '--host HOST',
-         description: 'Redis Host to connect to',
-         required: false,
-         default: '127.0.0.1'
-
-  option :port,
-         short: '-p PORT',
-         long: '--port PORT',
-         description: 'Redis Port to connect to',
-         proc: proc(&:to_i),
-         required: false,
-         default: 6379
-
-  option :password,
-         short: '-P PASSWORD',
-         long: '--password PASSWORD',
-         description: 'Redis Password to connect with'
-
-  option :conn_failure_status,
-         long: '--conn-failure-status EXIT_STATUS',
-         description: 'Returns the following exit status for Redis connection failures',
-         default: 'critical',
-         in: %w(unknown warning critical)
-
-  option :timeout,
-         short: '-t TIMEOUT',
-         long: '--timeout TIMEOUT',
-         description: 'Redis connection timeout',
-         proc: proc(&:to_i),
-         required: false,
-         default: 5
-
-  def redis_options
-    if config[:socket]
-      {
-        path:     config[:socket],
-        password: config[:password]
-      }
-    else
-      {
-        host:     config[:host],
-        port:     config[:port],
-        password: config[:password],
-        timeout:  config[:timeout]
-      }
-    end
-  end
+  include RedisClientOptions
 
   def run
-    if Redis.new(redis_options).ping == 'PONG'
+    if Redis.new(default_redis_options).ping == 'PONG'
       ok 'Redis is alive'
     else
       critical 'Redis did not respond to the ping command'
     end
   rescue
-    send(config[:conn_failure_status], "Could not connect to Redis server on #{config[:host]}:#{config[:port]}")
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_conn_info}")
   end
 end

--- a/bin/check-redis-slave-status.rb
+++ b/bin/check-redis-slave-status.rb
@@ -23,8 +23,8 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
       critical msg
     end
   rescue KeyError
-    critical "Redis server on #{redis_conn_info} is not master and does not have master_link_status"
+    critical "Redis server on #{redis_endpoint} is not master and does not have master_link_status"
   rescue
-    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_conn_info}")
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/bin/check-redis-slave-status.rb
+++ b/bin/check-redis-slave-status.rb
@@ -4,57 +4,13 @@
 
 require 'sensu-plugin/check/cli'
 require 'redis'
+require_relative '../lib/redis_client_options'
 
 class RedisSlaveCheck < Sensu::Plugin::Check::CLI
-  option :socket,
-         short: '-s SOCKET',
-         long: '--socket SOCKET',
-         description: 'Redis socket to connect to (overrides Host and Port)',
-         required: false
-
-  option :host,
-         short: '-h HOST',
-         long: '--host HOST',
-         description: 'Redis Host to connect to',
-         required: false,
-         default: '127.0.0.1'
-
-  option :port,
-         short: '-p PORT',
-         long: '--port PORT',
-         description: 'Redis Port to connect to',
-         proc: proc(&:to_i),
-         required: false,
-         default: 6379
-
-  option :password,
-         short: '-P PASSWORD',
-         long: '--password PASSWORD',
-         description: 'Redis Password to connect with'
-
-  option :conn_failure_status,
-         long: '--conn-failure-status EXIT_STATUS',
-         description: 'Returns the following exit status for Redis connection failures',
-         default: 'unknown',
-         in: %w(unknown warning critical)
-
-  option :timeout,
-         short: '-t TIMEOUT',
-         long: '--timeout TIMEOUT',
-         description: 'Redis connection timeout',
-         required: false,
-         proc: proc(&:to_i),
-         default: 5
+  include RedisClientOptions
 
   def run
-    options = if config[:socket]
-                { path: socket }
-              else
-                { host: config[:host], port: config[:port], timeout: config[:timeout] }
-              end
-
-    options[:password] = config[:password] if config[:password]
-    redis = Redis.new(options)
+    redis = Redis.new(default_redis_options)
 
     if redis.info.fetch('role') == 'master'
       ok 'This redis server is master'
@@ -67,8 +23,8 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
       critical msg
     end
   rescue KeyError
-    critical "Redis server on #{config[:host]}:#{config[:port]} is not master and does not have master_link_status"
+    critical "Redis server on #{redis_conn_info} is not master and does not have master_link_status"
   rescue
-    send(config[:conn_failure_status], "Could not connect to Redis server on #{config[:host]}:#{config[:port]}")
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_conn_info}")
   end
 end

--- a/bin/metrics-redis-graphite.rb
+++ b/bin/metrics-redis-graphite.rb
@@ -95,6 +95,6 @@ class Redis2Graphite < Sensu::Plugin::Metric::CLI::Graphite
 
     ok
   rescue
-    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_conn_info}")
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/bin/metrics-redis-llen.rb
+++ b/bin/metrics-redis-llen.rb
@@ -35,6 +35,6 @@ class RedisListLengthMetric < Sensu::Plugin::Metric::CLI::Graphite
     end
     ok
   rescue
-    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_conn_info}")
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/lib/redis_client_options.rb
+++ b/lib/redis_client_options.rb
@@ -1,0 +1,93 @@
+require 'redis'
+require 'sensu-plugin/metric/cli'
+
+module RedisClientOptions
+  def self.included(base)
+    base.extend(ClassMethods)
+    base.class_eval do
+      _configure_options
+    end
+  end
+
+  def default_redis_options
+    opts = {}
+    opts[:password] = config[:password] if config[:password]
+    opts[:timeout]  = config[:timeout]  if config[:timeout]
+    opts[:db]       = config[:database] if config[:database]
+
+    if config[:socket]
+      opts[:path] = config[:socket]
+    else
+      opts[:host] = config[:host]
+      opts[:port] = config[:port]
+    end
+    opts
+  end
+
+  def redis_conn_info
+    if config[:socket]
+      "unix://#{config[:socket]}"
+    else
+      "#{config[:host]}:#{config[:port]}"
+    end
+  end
+
+  module ClassMethods
+    def _configure_options
+      option :socket,
+             short: '-s SOCKET',
+             long: '--socket SOCKET',
+             description: 'Redis socket to connect to (overrides Host and Port)',
+             required: false
+
+      option :host,
+             short: '-h HOST',
+             long: '--host HOST',
+             description: 'Redis Host to connect to',
+             required: false,
+             default: Redis::Client::DEFAULTS[:host]
+
+      option :port,
+             short: '-p PORT',
+             long: '--port PORT',
+             description: 'Redis Port to connect to',
+             proc: proc(&:to_i),
+             required: false,
+             default: Redis::Client::DEFAULTS[:port]
+
+      option :database,
+             short: '-n DATABASE',
+             long: '--dbnumber DATABASE',
+             description: 'Redis database number to connect to',
+             proc: proc(&:to_i),
+             required: false,
+             default: Redis::Client::DEFAULTS[:db]
+
+      option :password,
+             short: '-P PASSWORD',
+             long: '--password PASSWORD',
+             description: 'Redis Password to connect with'
+
+      option :conn_failure_status,
+             long: '--conn-failure-status EXIT_STATUS',
+             description: 'Returns the following exit status for Redis connection failures',
+             default: 'critical',
+             in: %w(unknown warning critical)
+
+      option :timeout,
+             short: '-t TIMEOUT',
+             long: '--timeout TIMEOUT',
+             description: 'Redis connection timeout',
+             proc: proc(&:to_f),
+             required: false,
+             default: Redis::Client::DEFAULTS[:timeout]
+
+      option :reconnect_attempts,
+             description: 'Reconnect attempts to Redis host',
+             short: '-r ATTEMPTS',
+             long: '--reconnect ATTEMPTS',
+             proc: proc(&:to_i),
+             default: Redis::Client::DEFAULTS[:reconnect_attempts]
+    end
+  end
+end

--- a/lib/redis_client_options.rb
+++ b/lib/redis_client_options.rb
@@ -24,7 +24,7 @@ module RedisClientOptions
     opts
   end
 
-  def redis_conn_info
+  def redis_endpoint
     if config[:socket]
       "unix://#{config[:socket]}"
     else

--- a/test/bin/check-redis-info_spec.rb
+++ b/test/bin/check-redis-info_spec.rb
@@ -1,0 +1,31 @@
+require_relative '../spec_helper.rb'
+require_relative '../../bin/check-redis-info.rb'
+
+describe 'RedisSlaveCheck', '#run' do
+  before(:all) do
+    RedisSlaveCheck.class_variable_set(:@@autorun, nil)
+  end
+
+  it 'accepts config' do
+    args = %w(--host 10.0.0.1 --port 3456 --password foobar)
+    check = RedisSlaveCheck.new(args)
+    expect(check.default_redis_options[:password]).to eq 'foobar'
+    expect(check.default_redis_options[:host]).to eq '10.0.0.1'
+    expect(check.default_redis_options[:port]).to eq 3456
+  end
+
+  it 'sets socket option accordingly' do
+    args = %w(--socket /some/path/redis.sock)
+    check = RedisSlaveCheck.new(args)
+    expect(check.default_redis_options[:path]).to eq '/some/path/redis.sock'
+    expect(check.default_redis_options[:host]).to be_nil
+    expect(check.default_redis_options[:port]).to be_nil
+  end
+
+  it 'returns warning' do
+    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1)
+    check = RedisSlaveCheck.new(args)
+    expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+end

--- a/test/bin/check-redis-keys_spec.rb
+++ b/test/bin/check-redis-keys_spec.rb
@@ -1,0 +1,38 @@
+require_relative '../spec_helper.rb'
+require_relative '../../bin/check-redis-keys.rb'
+
+describe 'RedisKeysCheck', '#run' do
+  before(:all) do
+    RedisKeysCheck.class_variable_set(:@@autorun, nil)
+  end
+
+  it 'accepts config' do
+    args = %w(--host 10.0.0.1 --port 3456 --password foobar --warning 2 --critical 1)
+    check = RedisKeysCheck.new(args)
+    expect(check.default_redis_options[:password]).to eq 'foobar'
+    expect(check.default_redis_options[:host]).to eq '10.0.0.1'
+    expect(check.default_redis_options[:port]).to eq 3456
+  end
+
+  it 'sets socket option accordingly' do
+    args = %w(--socket /some/path/redis.sock --warning 2 --critical 1)
+    check = RedisKeysCheck.new(args)
+    expect(check.default_redis_options[:path]).to eq '/some/path/redis.sock'
+    expect(check.default_redis_options[:host]).to be_nil
+    expect(check.default_redis_options[:port]).to be_nil
+  end
+
+  it 'returns warning' do
+    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1 --warning 2  --critical 1)
+    check = RedisKeysCheck.new(args)
+    expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+
+  it 'returns warning' do
+    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1 --warning 2  --critical 1)
+    check = RedisKeysCheck.new(args)
+    expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+end

--- a/test/bin/check-redis-list-length_spec.rb
+++ b/test/bin/check-redis-list-length_spec.rb
@@ -1,0 +1,35 @@
+require_relative '../spec_helper.rb'
+require_relative '../../bin/check-redis-list-length.rb'
+
+describe 'RedisListLengthCheck', '#run' do
+  before(:all) do
+    RedisListLengthCheck.class_variable_set(:@@autorun, nil)
+  end
+
+  it 'accepts config' do
+    args = %w(--host 127.0.0.1 --password foobar --warning 2 --critical 1 -k key1)
+    check = RedisListLengthCheck.new(args)
+    expect(check.config[:password]).to eq 'foobar'
+  end
+
+  it 'sets socket option accordingly' do
+    args = %w(--socket /some/path/redis.sock --warning 2 --critical 1 -k key1)
+    check = RedisListLengthCheck.new(args)
+    expect(check.config[:socket]).to eq '/some/path/redis.sock'
+  end
+
+  it 'returns warning' do
+    args = %w(
+      --host 1.1.1.1
+      --port 1234
+      --conn-failure-status warning
+      --timeout 0.1
+      --warning 2
+      --critical 1
+      -k key1
+    )
+    check = RedisListLengthCheck.new(args)
+    expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+end

--- a/test/bin/check-redis-memory-percentage_spec.rb
+++ b/test/bin/check-redis-memory-percentage_spec.rb
@@ -1,0 +1,48 @@
+require_relative '../spec_helper.rb'
+require_relative '../../bin/check-redis-memory-percentage.rb'
+
+describe 'RedisChecks', '#run' do
+  before(:all) do
+    RedisChecks.class_variable_set(:@@autorun, nil)
+  end
+
+  it 'accepts config' do
+    args = %w(
+      --host 10.0.0.1
+      --port 3456
+      --password foobar
+      --warnmem 524288
+      --critmem 1048576
+    )
+    check = RedisChecks.new(args)
+    expect(check.default_redis_options[:password]).to eq 'foobar'
+    expect(check.default_redis_options[:host]).to eq '10.0.0.1'
+    expect(check.default_redis_options[:port]).to eq 3456
+  end
+
+  it 'sets socket option accordingly' do
+    args = %w(
+      --socket /some/path/redis.sock
+      --warnmem 524288
+      --critmem 1048576
+    )
+    check = RedisChecks.new(args)
+    expect(check.default_redis_options[:path]).to eq '/some/path/redis.sock'
+    expect(check.default_redis_options[:host]).to be_nil
+    expect(check.default_redis_options[:port]).to be_nil
+  end
+
+  it 'returns warning' do
+    args = %w(
+      --host 1.1.1.1
+      --port 1234
+      --conn-failure-status warning
+      --timeout 0.1
+      --warnmem 524288
+      --critmem 1048576
+    )
+    check = RedisChecks.new(args)
+    expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+end

--- a/test/bin/check-redis-memory_spec.rb
+++ b/test/bin/check-redis-memory_spec.rb
@@ -1,0 +1,43 @@
+require_relative '../spec_helper.rb'
+require_relative '../../bin/check-redis-memory.rb'
+
+describe 'RedisChecks', '#run' do
+  before(:all) do
+    RedisChecks.class_variable_set(:@@autorun, nil)
+  end
+
+  it 'accepts config' do
+    args = %w(
+      --host 127.0.0.1
+      --password foobar
+      --warnmem 524288
+      --critmem 1048576
+    )
+    check = RedisChecks.new(args)
+    expect(check.config[:password]).to eq 'foobar'
+  end
+
+  it 'sets socket option accordingly' do
+    args = %w(
+      --socket /some/path/redis.sock
+      --warnmem 524288
+      --critmem 1048576
+    )
+    check = RedisChecks.new(args)
+    expect(check.config[:socket]).to eq '/some/path/redis.sock'
+  end
+
+  it 'returns warning' do
+    args = %w(
+      --host 1.1.1.1
+      --port 1234
+      --conn-failure-status warning
+      --timeout 0.1
+      --warnmem 524288
+      --critmem 1048576
+    )
+    check = RedisChecks.new(args)
+    expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+end

--- a/test/bin/check-redis-ping_spec.rb
+++ b/test/bin/check-redis-ping_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../spec_helper.rb'
+require_relative '../../bin/check-redis-ping.rb'
+
+describe 'CheckRedisPing', '#run' do
+  before(:all) do
+    RedisPing.class_variable_set(:@@autorun, nil)
+  end
+
+  it 'accepts config' do
+    args = %w(--host 127.0.0.1 --password foobar)
+    check = RedisPing.new(args)
+    expect(check.config[:password]).to eq 'foobar'
+  end
+
+  it 'sets socket option accordingly' do
+    args = %w(--socket /some/path/redis.sock)
+    check = RedisPing.new(args)
+    expect(check.config[:socket]).to eq '/some/path/redis.sock'
+  end
+
+  it 'returns warning' do
+    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1)
+    check = RedisPing.new(args)
+    expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+end

--- a/test/bin/check-redis-slave-status_spec.rb
+++ b/test/bin/check-redis-slave-status_spec.rb
@@ -1,0 +1,31 @@
+require_relative '../spec_helper.rb'
+require_relative '../../bin/check-redis-slave-status.rb'
+
+describe 'RedisSlaveCheck', '#run' do
+  before(:all) do
+    RedisSlaveCheck.class_variable_set(:@@autorun, nil)
+  end
+
+  it 'accepts config' do
+    args = %w(--host 10.0.0.1 --port 3456 --password foobar)
+    check = RedisSlaveCheck.new(args)
+    expect(check.default_redis_options[:password]).to eq 'foobar'
+    expect(check.default_redis_options[:host]).to eq '10.0.0.1'
+    expect(check.default_redis_options[:port]).to eq 3456
+  end
+
+  it 'sets socket option accordingly' do
+    args = %w(--socket /some/path/redis.sock)
+    check = RedisSlaveCheck.new(args)
+    expect(check.default_redis_options[:path]).to eq '/some/path/redis.sock'
+    expect(check.default_redis_options[:host]).to be_nil
+    expect(check.default_redis_options[:port]).to be_nil
+  end
+
+  it 'returns warning' do
+    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1)
+    check = RedisSlaveCheck.new(args)
+    expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+end

--- a/test/bin/metrics-redis-graphite_spec.rb
+++ b/test/bin/metrics-redis-graphite_spec.rb
@@ -1,0 +1,31 @@
+require_relative '../spec_helper.rb'
+require_relative '../../bin/metrics-redis-graphite.rb'
+
+describe 'Redis2Graphite', '#run' do
+  before(:all) do
+    Redis2Graphite.class_variable_set(:@@autorun, nil)
+  end
+
+  it 'accepts config' do
+    args = %w(--host 10.0.0.1 --port 3456 --password foobar)
+    check = Redis2Graphite.new(args)
+    expect(check.default_redis_options[:password]).to eq 'foobar'
+    expect(check.default_redis_options[:host]).to eq '10.0.0.1'
+    expect(check.default_redis_options[:port]).to eq 3456
+  end
+
+  it 'sets socket option accordingly' do
+    args = %w(--socket /some/path/redis.sock)
+    check = Redis2Graphite.new(args)
+    expect(check.default_redis_options[:path]).to eq '/some/path/redis.sock'
+    expect(check.default_redis_options[:host]).to be_nil
+    expect(check.default_redis_options[:port]).to be_nil
+  end
+
+  it 'returns warning' do
+    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1)
+    check = Redis2Graphite.new(args)
+    expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+end

--- a/test/bin/metrics-redis-llen_spec.rb
+++ b/test/bin/metrics-redis-llen_spec.rb
@@ -1,0 +1,31 @@
+require_relative '../spec_helper.rb'
+require_relative '../../bin/metrics-redis-llen.rb'
+
+describe 'RedisListLengthMetric', '#run' do
+  before(:all) do
+    RedisListLengthMetric.class_variable_set(:@@autorun, nil)
+  end
+
+  it 'accepts config' do
+    args = %w(--host 10.0.0.1 --port 3456 --password foobar -k key1)
+    check = RedisListLengthMetric.new(args)
+    expect(check.default_redis_options[:password]).to eq 'foobar'
+    expect(check.default_redis_options[:host]).to eq '10.0.0.1'
+    expect(check.default_redis_options[:port]).to eq 3456
+  end
+
+  it 'sets socket option accordingly' do
+    args = %w(--socket /some/path/redis.sock -k key1)
+    check = RedisListLengthMetric.new(args)
+    expect(check.default_redis_options[:path]).to eq '/some/path/redis.sock'
+    expect(check.default_redis_options[:host]).to be_nil
+    expect(check.default_redis_options[:port]).to be_nil
+  end
+
+  it 'returns warning' do
+    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1 -k key1)
+    check = RedisListLengthMetric.new(args)
+    expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+end

--- a/test/lib/redis_client_options_spec.rb
+++ b/test/lib/redis_client_options_spec.rb
@@ -34,12 +34,12 @@ describe 'DummyRedisCheck', '#run' do
   it 'output conn info for host:port' do
     args = %w(--host 10.0.0.1 --port 3456)
     check = DummyRedisCheck.new(args)
-    expect(check.redis_conn_info).to eq '10.0.0.1:3456'
+    expect(check.redis_endpoint).to eq '10.0.0.1:3456'
   end
 
   it 'output conn info for host:port' do
     args = %w(--socket /some/path/redis.sock --host 10.0.0.1 --port 3456)
     check = DummyRedisCheck.new(args)
-    expect(check.redis_conn_info).to eq 'unix:///some/path/redis.sock'
+    expect(check.redis_endpoint).to eq 'unix:///some/path/redis.sock'
   end
 end

--- a/test/lib/redis_client_options_spec.rb
+++ b/test/lib/redis_client_options_spec.rb
@@ -1,0 +1,45 @@
+require_relative '../spec_helper.rb'
+require_relative '../../lib/redis_client_options.rb'
+require 'redis'
+
+class DummyRedisCheck < Sensu::Plugin::Check::CLI
+  include RedisClientOptions
+
+  def run
+    Redis.new(default_redis_options).ping
+  end
+end
+
+describe 'DummyRedisCheck', '#run' do
+  it 'accepts config' do
+    args = %w(--host 127.0.0.1 --password foobar)
+    check = DummyRedisCheck.new(args)
+    expect(check.config[:password]).to eq 'foobar'
+  end
+
+  it 'sets socket option accordingly' do
+    args = %w(--socket /some/path/redis.sock)
+    check = DummyRedisCheck.new(args)
+    expect(check.config[:socket]).to eq '/some/path/redis.sock'
+  end
+
+  it 'prefers socket option over host:port' do
+    args = %w(--host 10.0.0.1 -port 3456 --socket /some/path/redis.sock)
+    check = DummyRedisCheck.new(args)
+    expect(check.default_redis_options[:path]).to eq '/some/path/redis.sock'
+    expect(check.default_redis_options[:host]).to be_nil
+    expect(check.default_redis_options[:port]).to be_nil
+  end
+
+  it 'output conn info for host:port' do
+    args = %w(--host 10.0.0.1 --port 3456)
+    check = DummyRedisCheck.new(args)
+    expect(check.redis_conn_info).to eq '10.0.0.1:3456'
+  end
+
+  it 'output conn info for host:port' do
+    args = %w(--socket /some/path/redis.sock --host 10.0.0.1 --port 3456)
+    check = DummyRedisCheck.new(args)
+    expect(check.redis_conn_info).to eq 'unix:///some/path/redis.sock'
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No, I think I should have created on, though.

#### General

- [x] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass

#### New Plugins

- [x] Tests

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Fix a bug + improve reliability/maintainability of the scripts

#### Known Compatibility Issues

**TL;DR I believe I have introduced a bug in #32 that made _check-redis-ping.rb_ the only script that actually works with Unix sockets. This PR is a proper fix for this.**

I wanted to do a simple fix, but then realized that for the sake of reliability a proper refactoring was in order, so this ended up being a bigger rewrite than intended.

 ------

More details from commit message:
While providing an option to connect to Redis via Unix socket (#32), a
bug was introduced that made majority of the scripts silently ignore the
socket option and use default host/port instead. This was mainly due to
bad copypasta.

This commit, unifies all the CLI options in one module
(RedisClientOptions) and provides unit tests. Also, as a regression
suite, all scripts have basic tests added to make sure they properly
include the module.

This change should also make it easy to maintain a consistent UX by
having one place where options, defaults and description strings can be
modified.
