### PR TITLE
locked `development_dependency` of `mixlib-shellout` on to fix ruby 2.1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+### Fixed
+- locked `development_dependency` of `mixlib-shellout` on to fix ruby 2.1 support (@majormoses)
+
 ## [2.3.1] - 2017-12-08
 ### Fixed
 - ensure that `--socket` option is properly parsed and takes precedence over `--host`/`--port` (@mbyczkowski)

--- a/sensu-plugins-redis.gemspec
+++ b/sensu-plugins-redis.gemspec
@@ -35,19 +35,22 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsRedis::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
+
   s.add_runtime_dependency 'redis',        '~> 3.3'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'github-markup',             '~> 1.3'
+  s.add_development_dependency 'kitchen-docker',            '~> 2.6'
+  s.add_development_dependency 'kitchen-localhost',         '~> 0.3'
+  # locked to keep ruby 2.1 support, this is pulled in by test-kitchen
+  s.add_development_dependency 'mixlib-shellout',           ['< 2.3.0', '~> 2.2']
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.0'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.1'
   s.add_development_dependency 'rubocop',                   '~> 0.40.0'
-  s.add_development_dependency 'yard',                      '~> 0.8'
   s.add_development_dependency 'serverspec',                '~> 2.36.1'
   s.add_development_dependency 'test-kitchen',              '~> 1.16.0'
-  s.add_development_dependency 'kitchen-docker',            '~> 2.6'
-  s.add_development_dependency 'kitchen-localhost',         '~> 0.3'
+  s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
#### General

- [ ] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose
lock deps to fix support 2.1
#### Known Compatibility Issues
none