### PR TITLE
feat: add check-redis-connections-available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines ](https://
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- check-redis-connections-available.rb: checks the number of connections available (@nishiki)
 
 ## [2.3.2] - 2017-12-21
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
  * bin/check-redis-memory-percentage.rb
  * bin/check-redis-ping.rb
  * bin/check-redis-slave-status.rb
+ * bin/check-redis-connections-available.rb
  * bin/metrics-redis-graphite.rb
  * bin/metrics-redis-llen.rb
 

--- a/bin/check-redis-connections-available.rb
+++ b/bin/check-redis-connections-available.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+#
+#   check-redis-connection.rb
+#
+# DESCRIPTION:
+#   This plugin checks the number of connections available on redis
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#   check-redis-connections-available.rb -c COUNT -w COUNT -h HOST
+#
+# LICENSE:
+#   Copyright Adrien Waksberg <adrien.waksberg@doctolib.fr>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'redis'
+require_relative '../lib/redis_client_options'
+
+class RedisConnectionsAvailable < Sensu::Plugin::Check::CLI
+  include RedisClientOptions
+
+  option :critical,
+         short: '-c COUNT',
+         long: '--critical COUNT',
+         description: 'COUNT critical threshold for number of connections available',
+         proc: proc(&:to_i),
+         required: true
+
+  option :warning,
+         short: '-w COUNT',
+         long: '--warning COUNT',
+         description: 'COUNT warning threshold for number of connections available',
+         proc: proc(&:to_i),
+         required: true
+
+  def run
+    redis = Redis.new(default_redis_options)
+    maxclients = redis.config('get', 'maxclients').last.to_i
+    clients = redis.info.fetch('connected_clients').to_i
+    conn_available = maxclients - clients
+
+    if conn_available <= config[:critical]
+      critical "Only #{conn_available} connections left available (#{clients}/#{maxclients})"
+    elsif conn_available <= config[:warning]
+      warning "Only #{conn_available} connections left available (#{clients}/#{maxclients})"
+    else
+      ok "There are #{conn_available} connections available (#{clients}/#{maxclients})"
+    end
+
+  rescue
+    send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
+  end
+end

--- a/test/bin/check-redis-connections-available_spec.rb
+++ b/test/bin/check-redis-connections-available_spec.rb
@@ -1,0 +1,38 @@
+require_relative '../spec_helper.rb'
+require_relative '../../bin/check-redis-connections-available.rb'
+
+describe 'RedisConnectionsAvailable', '#run' do
+  before(:all) do
+    RedisConnectionsAvailable.class_variable_set(:@@autorun, nil)
+  end
+
+  it 'accepts config' do
+    args = %w(--host 10.0.0.1 --port 3456 --password foobar --warning 2 --critical 1)
+    check = RedisConnectionsAvailable.new(args)
+    expect(check.default_redis_options[:password]).to eq 'foobar'
+    expect(check.default_redis_options[:host]).to eq '10.0.0.1'
+    expect(check.default_redis_options[:port]).to eq 3456
+  end
+
+  it 'sets socket option accordingly' do
+    args = %w(--socket /some/path/redis.sock --warning 2 --critical 1)
+    check = RedisConnectionsAvailable.new(args)
+    expect(check.default_redis_options[:path]).to eq '/some/path/redis.sock'
+    expect(check.default_redis_options[:host]).to be_nil
+    expect(check.default_redis_options[:port]).to be_nil
+  end
+
+  it 'returns warning' do
+    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1 --warning 2  --critical 1)
+    check = RedisConnectionsAvailable.new(args)
+    expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+
+  it 'returns warning' do
+    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1 --warning 2  --critical 1)
+    check = RedisConnectionsAvailable.new(args)
+    expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+end

--- a/test/integration/helpers/serverspec/check-redis-connections-available_spec.rb
+++ b/test/integration/helpers/serverspec/check-redis-connections-available_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'shared_spec'
+
+gem_path = '/usr/local/bin'
+check_name = 'check-redis-connections-available.rb'
+check = "#{gem_path}/#{check_name}"
+
+describe 'ruby environment' do
+  it_behaves_like 'ruby checks', check
+end
+
+describe command("#{check} -P foobared -w 1 -c 2") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match('OK') }
+end
+
+describe command("#{check} -P foobared -w 9999 -c 2") do
+  its(:exit_status) { should eq 1 }
+  its(:stdout) { should match('WARNING') }
+end
+
+describe command("#{check} -P foobared -w 1 -c 9999") do
+  its(:exit_status) { should eq 2 }
+  its(:stdout) { should match('CRITICAL') }
+end


### PR DESCRIPTION
## Pull Request Checklist

Hello,

I created a new check for sensu, it checks the number of connections available before reaching the maxclients limit.

```
$ /opt/sensu/embedded/bin/ruby  check-redis-connections-available.rb -c 4094 -w 0
RedisConnectionsAvailable CRITICAL: Only 4086 connections left available (10/4096)
$ /opt/sensu/embedded/bin/ruby  check-redis-connections-available.rb -c 0 -w 4094
RedisConnectionsAvailable WARNING: Only 4086 connections left available (10/4096)
$ /opt/sensu/embedded/bin/ruby  check-redis-connections-available.rb -c 5 -w 10
RedisConnectionsAvailable OK: There are 4086 connections available (10/4096)
```
Regards,

#### General

- [X] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass

#### New Plugins

- [X] Tests

- [X] Add the plugin to the README

- [X] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
