### PR TITLE
[CVE-2017-8418] - updating rubocop dependency.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,8 @@ RegexpLiteral:
 
 Style/Documentation:
   Enabled: false
+
+# tests can be slow
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
 install:
 - bundle install
 rvm:
-- 2.0
 - 2.1
 - 2.2
 - 2.3.0
@@ -33,7 +32,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.0
     rvm: 2.1
     rvm: 2.2
     rvm: 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,18 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+### Security
+- updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418. (@majormoses)
+
+### Breaking Changes
+- removed ruby `< 2.1` support (@majormoses)
+
+### Changed
+- appeased the cops (@majormoses)
+
 ## [2.4.0] - 2018-03-14
 ### Added
 - check-redis-connections-available.rb: checks the number of connections available (@nishiki)
-
 ## [2.3.2] - 2017-12-21
 ### Fixed
 - locked `development_dependency` of `mixlib-shellout` on to fix ruby 2.1 support (@majormoses)

--- a/Rakefile
+++ b/Rakefile
@@ -8,9 +8,9 @@ require 'yard/rake/yardoc_task'
 require 'kitchen/rake_tasks'
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new
@@ -57,6 +57,6 @@ task :integration do
   threads.map(&:join)
 end
 
-task default: %i(make_bin_executable yard rubocop check_binstubs integration)
+task default: %i[make_bin_executable yard rubocop check_binstubs integration]
 
-task quick: %i(make_bin_executable yard rubocop check_binstubs unit)
+task quick: %i[make_bin_executable yard rubocop check_binstubs unit]

--- a/bin/check-redis-connections-available.rb
+++ b/bin/check-redis-connections-available.rb
@@ -57,8 +57,7 @@ class RedisConnectionsAvailable < Sensu::Plugin::Check::CLI
     else
       ok "There are #{conn_available} connections available (#{clients}/#{maxclients})"
     end
-
-  rescue
+  rescue StandardError
     send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/bin/check-redis-info.rb
+++ b/bin/check-redis-info.rb
@@ -45,7 +45,7 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
     else
       critical "Redis #{config[:redis_info_key]} is #{redis.info.fetch(config[:redis_info_key].to_s)}!"
     end
-  rescue
+  rescue StandardError
     send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/bin/check-redis-keys.rb
+++ b/bin/check-redis-keys.rb
@@ -49,7 +49,7 @@ class RedisKeysCheck < Sensu::Plugin::Check::CLI
     else
       ok "Redis list #{config[:pattern]} length is above thresholds"
     end
-  rescue
+  rescue StandardError
     send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/bin/check-redis-list-length.rb
+++ b/bin/check-redis-list-length.rb
@@ -57,7 +57,7 @@ class RedisListLengthCheck < Sensu::Plugin::Check::CLI
     else
       ok "Redis list #{config[:key]} length (#{length}) is below thresholds"
     end
-  rescue
+  rescue StandardError
     send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/bin/check-redis-memory-percentage.rb
+++ b/bin/check-redis-memory-percentage.rb
@@ -57,7 +57,7 @@ class RedisChecks < Sensu::Plugin::Check::CLI
 
     redis_info = redis.info
     max_memory = redis_info.fetch('maxmemory', 0).to_i
-    if max_memory == 0
+    if max_memory.zero?
       max_memory = redis_info.fetch('total_system_memory', system_memory).to_i
     end
     memory_in_use = redis_info.fetch('used_memory').to_i.fdiv(1024) # used memory in KB (KiloBytes)
@@ -73,7 +73,7 @@ class RedisChecks < Sensu::Plugin::Check::CLI
     else
       ok "Redis memory usage: #{used_memory}% is below defined limits"
     end
-  rescue
+  rescue StandardError
     send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/bin/check-redis-memory.rb
+++ b/bin/check-redis-memory.rb
@@ -42,7 +42,7 @@ class RedisChecks < Sensu::Plugin::Check::CLI
     else
       ok "Redis memory usage: #{used_memory}KB is below defined limits"
     end
-  rescue
+  rescue StandardError
     send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/bin/check-redis-ping.rb
+++ b/bin/check-redis-ping.rb
@@ -1,5 +1,5 @@
 #! /usr/bin/env ruby
-#  encoding: UTF-8
+
 #   <script name>
 #
 # DESCRIPTION:
@@ -40,7 +40,7 @@ class RedisPing < Sensu::Plugin::Check::CLI
     else
       critical 'Redis did not respond to the ping command'
     end
-  rescue
+  rescue StandardError
     send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/bin/check-redis-slave-status.rb
+++ b/bin/check-redis-slave-status.rb
@@ -24,7 +24,7 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
     end
   rescue KeyError
     critical "Redis server on #{redis_endpoint} is not master and does not have master_link_status"
-  rescue
+  rescue StandardError
     send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/bin/metrics-redis-graphite.rb
+++ b/bin/metrics-redis-graphite.rb
@@ -88,13 +88,13 @@ class Redis2Graphite < Sensu::Plugin::Metric::CLI::Graphite
 
     # Loop thru commandstats entries for perf metrics
     redis.info('commandstats').each do |k, v|
-      %w(calls usec_per_call usec).each do |x|
+      %w[calls usec_per_call usec].each do |x|
         output "#{config[:scheme]}.commandstats.#{k}.#{x}", v[x]
       end
     end
 
     ok
-  rescue
+  rescue StandardError
     send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/bin/metrics-redis-llen.rb
+++ b/bin/metrics-redis-llen.rb
@@ -34,7 +34,7 @@ class RedisListLengthMetric < Sensu::Plugin::Metric::CLI::Graphite
       output "#{config[:scheme]}.#{key}.items", redis.llen(key)
     end
     ok
-  rescue
+  rescue StandardError
     send(config[:conn_failure_status], "Could not connect to Redis server on #{redis_endpoint}")
   end
 end

--- a/lib/redis_client_options.rb
+++ b/lib/redis_client_options.rb
@@ -72,7 +72,7 @@ module RedisClientOptions
              long: '--conn-failure-status EXIT_STATUS',
              description: 'Returns the following exit status for Redis connection failures',
              default: 'critical',
-             in: %w(unknown warning critical)
+             in: %w[unknown warning critical]
 
       option :timeout,
              short: '-t TIMEOUT',

--- a/sensu-plugins-redis.gemspec
+++ b/sensu-plugins-redis.gemspec
@@ -5,7 +5,7 @@ require 'date'
 
 require_relative 'lib/sensu-plugins-redis'
 
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu-Plugins and contributors']
 
   s.date                   = Date.today.to_s
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
                               status, `INFO` metrics, key counts, list lengths,
                               and more.'
   s.email                  = '<sensu-users@googlegroups.com>'
-  s.files                  = Dir.glob('{bin,lib}/**/*.rb') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*.rb') + %w[LICENSE README.md CHANGELOG.md]
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-redis'
   s.license                = 'MIT'
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.1.0'
 
   s.summary                = 'Sensu plugins for working with redis'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
@@ -49,7 +49,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake',                      '~> 10.0'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.1'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
+  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
   s.add_development_dependency 'serverspec',                '~> 2.36.1'
   s.add_development_dependency 'test-kitchen',              '~> 1.16.0'
   s.add_development_dependency 'yard',                      '~> 0.8'

--- a/test/bin/check-redis-connections-available_spec.rb
+++ b/test/bin/check-redis-connections-available_spec.rb
@@ -7,7 +7,7 @@ describe 'RedisConnectionsAvailable', '#run' do
   end
 
   it 'accepts config' do
-    args = %w(--host 10.0.0.1 --port 3456 --password foobar --warning 2 --critical 1)
+    args = %w[--host 10.0.0.1 --port 3456 --password foobar --warning 2 --critical 1]
     check = RedisConnectionsAvailable.new(args)
     expect(check.default_redis_options[:password]).to eq 'foobar'
     expect(check.default_redis_options[:host]).to eq '10.0.0.1'
@@ -15,7 +15,7 @@ describe 'RedisConnectionsAvailable', '#run' do
   end
 
   it 'sets socket option accordingly' do
-    args = %w(--socket /some/path/redis.sock --warning 2 --critical 1)
+    args = %w[--socket /some/path/redis.sock --warning 2 --critical 1]
     check = RedisConnectionsAvailable.new(args)
     expect(check.default_redis_options[:path]).to eq '/some/path/redis.sock'
     expect(check.default_redis_options[:host]).to be_nil
@@ -23,14 +23,14 @@ describe 'RedisConnectionsAvailable', '#run' do
   end
 
   it 'returns warning' do
-    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1 --warning 2  --critical 1)
+    args = %w[--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1 --warning 2 --critical 1]
     check = RedisConnectionsAvailable.new(args)
     expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)
   end
 
   it 'returns warning' do
-    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1 --warning 2  --critical 1)
+    args = %w[--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1 --warning 2 --critical 1]
     check = RedisConnectionsAvailable.new(args)
     expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)

--- a/test/bin/check-redis-info_spec.rb
+++ b/test/bin/check-redis-info_spec.rb
@@ -7,7 +7,7 @@ describe 'RedisSlaveCheck', '#run' do
   end
 
   it 'accepts config' do
-    args = %w(--host 10.0.0.1 --port 3456 --password foobar)
+    args = %w[--host 10.0.0.1 --port 3456 --password foobar]
     check = RedisSlaveCheck.new(args)
     expect(check.default_redis_options[:password]).to eq 'foobar'
     expect(check.default_redis_options[:host]).to eq '10.0.0.1'
@@ -15,7 +15,7 @@ describe 'RedisSlaveCheck', '#run' do
   end
 
   it 'sets socket option accordingly' do
-    args = %w(--socket /some/path/redis.sock)
+    args = %w[--socket /some/path/redis.sock]
     check = RedisSlaveCheck.new(args)
     expect(check.default_redis_options[:path]).to eq '/some/path/redis.sock'
     expect(check.default_redis_options[:host]).to be_nil
@@ -23,7 +23,7 @@ describe 'RedisSlaveCheck', '#run' do
   end
 
   it 'returns warning' do
-    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1)
+    args = %w[--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1)]
     check = RedisSlaveCheck.new(args)
     expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)

--- a/test/bin/check-redis-keys_spec.rb
+++ b/test/bin/check-redis-keys_spec.rb
@@ -7,7 +7,7 @@ describe 'RedisKeysCheck', '#run' do
   end
 
   it 'accepts config' do
-    args = %w(--host 10.0.0.1 --port 3456 --password foobar --warning 2 --critical 1)
+    args = %w[--host 10.0.0.1 --port 3456 --password foobar --warning 2 --critical 1]
     check = RedisKeysCheck.new(args)
     expect(check.default_redis_options[:password]).to eq 'foobar'
     expect(check.default_redis_options[:host]).to eq '10.0.0.1'
@@ -15,7 +15,7 @@ describe 'RedisKeysCheck', '#run' do
   end
 
   it 'sets socket option accordingly' do
-    args = %w(--socket /some/path/redis.sock --warning 2 --critical 1)
+    args = %w[--socket /some/path/redis.sock --warning 2 --critical 1]
     check = RedisKeysCheck.new(args)
     expect(check.default_redis_options[:path]).to eq '/some/path/redis.sock'
     expect(check.default_redis_options[:host]).to be_nil
@@ -23,14 +23,14 @@ describe 'RedisKeysCheck', '#run' do
   end
 
   it 'returns warning' do
-    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1 --warning 2  --critical 1)
+    args = %w[--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1 --warning 2 --critical 1]
     check = RedisKeysCheck.new(args)
     expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)
   end
 
   it 'returns warning' do
-    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1 --warning 2  --critical 1)
+    args = %w[--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1 --warning 2 --critical 1]
     check = RedisKeysCheck.new(args)
     expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)

--- a/test/bin/check-redis-list-length_spec.rb
+++ b/test/bin/check-redis-list-length_spec.rb
@@ -7,19 +7,19 @@ describe 'RedisListLengthCheck', '#run' do
   end
 
   it 'accepts config' do
-    args = %w(--host 127.0.0.1 --password foobar --warning 2 --critical 1 -k key1)
+    args = %w[--host 127.0.0.1 --password foobar --warning 2 --critical 1 -k key1]
     check = RedisListLengthCheck.new(args)
     expect(check.config[:password]).to eq 'foobar'
   end
 
   it 'sets socket option accordingly' do
-    args = %w(--socket /some/path/redis.sock --warning 2 --critical 1 -k key1)
+    args = %w[--socket /some/path/redis.sock --warning 2 --critical 1 -k key1]
     check = RedisListLengthCheck.new(args)
     expect(check.config[:socket]).to eq '/some/path/redis.sock'
   end
 
   it 'returns warning' do
-    args = %w(
+    args = %w[
       --host 1.1.1.1
       --port 1234
       --conn-failure-status warning
@@ -27,7 +27,7 @@ describe 'RedisListLengthCheck', '#run' do
       --warning 2
       --critical 1
       -k key1
-    )
+    ]
     check = RedisListLengthCheck.new(args)
     expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)

--- a/test/bin/check-redis-memory-percentage_spec.rb
+++ b/test/bin/check-redis-memory-percentage_spec.rb
@@ -7,13 +7,13 @@ describe 'RedisChecks', '#run' do
   end
 
   it 'accepts config' do
-    args = %w(
+    args = %w[
       --host 10.0.0.1
       --port 3456
       --password foobar
       --warnmem 524288
       --critmem 1048576
-    )
+    ]
     check = RedisChecks.new(args)
     expect(check.default_redis_options[:password]).to eq 'foobar'
     expect(check.default_redis_options[:host]).to eq '10.0.0.1'
@@ -21,11 +21,11 @@ describe 'RedisChecks', '#run' do
   end
 
   it 'sets socket option accordingly' do
-    args = %w(
+    args = %w[
       --socket /some/path/redis.sock
       --warnmem 524288
       --critmem 1048576
-    )
+    ]
     check = RedisChecks.new(args)
     expect(check.default_redis_options[:path]).to eq '/some/path/redis.sock'
     expect(check.default_redis_options[:host]).to be_nil
@@ -33,14 +33,14 @@ describe 'RedisChecks', '#run' do
   end
 
   it 'returns warning' do
-    args = %w(
+    args = %w[
       --host 1.1.1.1
       --port 1234
       --conn-failure-status warning
       --timeout 0.1
       --warnmem 524288
       --critmem 1048576
-    )
+    ]
     check = RedisChecks.new(args)
     expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)

--- a/test/bin/check-redis-memory_spec.rb
+++ b/test/bin/check-redis-memory_spec.rb
@@ -7,35 +7,35 @@ describe 'RedisChecks', '#run' do
   end
 
   it 'accepts config' do
-    args = %w(
+    args = %w[
       --host 127.0.0.1
       --password foobar
       --warnmem 524288
       --critmem 1048576
-    )
+    ]
     check = RedisChecks.new(args)
     expect(check.config[:password]).to eq 'foobar'
   end
 
   it 'sets socket option accordingly' do
-    args = %w(
+    args = %w[
       --socket /some/path/redis.sock
       --warnmem 524288
       --critmem 1048576
-    )
+    ]
     check = RedisChecks.new(args)
     expect(check.config[:socket]).to eq '/some/path/redis.sock'
   end
 
   it 'returns warning' do
-    args = %w(
+    args = %w[
       --host 1.1.1.1
       --port 1234
       --conn-failure-status warning
       --timeout 0.1
       --warnmem 524288
       --critmem 1048576
-    )
+    ]
     check = RedisChecks.new(args)
     expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)

--- a/test/bin/check-redis-ping_spec.rb
+++ b/test/bin/check-redis-ping_spec.rb
@@ -7,19 +7,19 @@ describe 'CheckRedisPing', '#run' do
   end
 
   it 'accepts config' do
-    args = %w(--host 127.0.0.1 --password foobar)
+    args = %w[--host 127.0.0.1 --password foobar]
     check = RedisPing.new(args)
     expect(check.config[:password]).to eq 'foobar'
   end
 
   it 'sets socket option accordingly' do
-    args = %w(--socket /some/path/redis.sock)
+    args = %w[--socket /some/path/redis.sock]
     check = RedisPing.new(args)
     expect(check.config[:socket]).to eq '/some/path/redis.sock'
   end
 
   it 'returns warning' do
-    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1)
+    args = %w[--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1]
     check = RedisPing.new(args)
     expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)

--- a/test/bin/check-redis-slave-status_spec.rb
+++ b/test/bin/check-redis-slave-status_spec.rb
@@ -7,7 +7,7 @@ describe 'RedisSlaveCheck', '#run' do
   end
 
   it 'accepts config' do
-    args = %w(--host 10.0.0.1 --port 3456 --password foobar)
+    args = %w[--host 10.0.0.1 --port 3456 --password foobar]
     check = RedisSlaveCheck.new(args)
     expect(check.default_redis_options[:password]).to eq 'foobar'
     expect(check.default_redis_options[:host]).to eq '10.0.0.1'
@@ -15,7 +15,7 @@ describe 'RedisSlaveCheck', '#run' do
   end
 
   it 'sets socket option accordingly' do
-    args = %w(--socket /some/path/redis.sock)
+    args = %w[--socket /some/path/redis.sock]
     check = RedisSlaveCheck.new(args)
     expect(check.default_redis_options[:path]).to eq '/some/path/redis.sock'
     expect(check.default_redis_options[:host]).to be_nil
@@ -23,7 +23,7 @@ describe 'RedisSlaveCheck', '#run' do
   end
 
   it 'returns warning' do
-    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1)
+    args = %w[--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1]
     check = RedisSlaveCheck.new(args)
     expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)

--- a/test/bin/metrics-redis-graphite_spec.rb
+++ b/test/bin/metrics-redis-graphite_spec.rb
@@ -7,7 +7,7 @@ describe 'Redis2Graphite', '#run' do
   end
 
   it 'accepts config' do
-    args = %w(--host 10.0.0.1 --port 3456 --password foobar)
+    args = %w[--host 10.0.0.1 --port 3456 --password foobar]
     check = Redis2Graphite.new(args)
     expect(check.default_redis_options[:password]).to eq 'foobar'
     expect(check.default_redis_options[:host]).to eq '10.0.0.1'
@@ -15,7 +15,7 @@ describe 'Redis2Graphite', '#run' do
   end
 
   it 'sets socket option accordingly' do
-    args = %w(--socket /some/path/redis.sock)
+    args = %w[--socket /some/path/redis.sock]
     check = Redis2Graphite.new(args)
     expect(check.default_redis_options[:path]).to eq '/some/path/redis.sock'
     expect(check.default_redis_options[:host]).to be_nil
@@ -23,7 +23,7 @@ describe 'Redis2Graphite', '#run' do
   end
 
   it 'returns warning' do
-    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1)
+    args = %w[--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1]
     check = Redis2Graphite.new(args)
     expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)

--- a/test/bin/metrics-redis-llen_spec.rb
+++ b/test/bin/metrics-redis-llen_spec.rb
@@ -7,7 +7,7 @@ describe 'RedisListLengthMetric', '#run' do
   end
 
   it 'accepts config' do
-    args = %w(--host 10.0.0.1 --port 3456 --password foobar -k key1)
+    args = %w[--host 10.0.0.1 --port 3456 --password foobar -k key1]
     check = RedisListLengthMetric.new(args)
     expect(check.default_redis_options[:password]).to eq 'foobar'
     expect(check.default_redis_options[:host]).to eq '10.0.0.1'
@@ -15,7 +15,7 @@ describe 'RedisListLengthMetric', '#run' do
   end
 
   it 'sets socket option accordingly' do
-    args = %w(--socket /some/path/redis.sock -k key1)
+    args = %w[--socket /some/path/redis.sock -k key1]
     check = RedisListLengthMetric.new(args)
     expect(check.default_redis_options[:path]).to eq '/some/path/redis.sock'
     expect(check.default_redis_options[:host]).to be_nil
@@ -23,7 +23,7 @@ describe 'RedisListLengthMetric', '#run' do
   end
 
   it 'returns warning' do
-    args = %w(--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1 -k key1)
+    args = %w[--host 1.1.1.1 --port 1234 --conn-failure-status warning --timeout 0.1 -k key1]
     check = RedisListLengthMetric.new(args)
     expect(check).to receive(:warning).with('Could not connect to Redis server on 1.1.1.1:1234').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)

--- a/test/lib/redis_client_options_spec.rb
+++ b/test/lib/redis_client_options_spec.rb
@@ -12,19 +12,19 @@ end
 
 describe 'DummyRedisCheck', '#run' do
   it 'accepts config' do
-    args = %w(--host 127.0.0.1 --password foobar)
+    args = %w[--host 127.0.0.1 --password foobar]
     check = DummyRedisCheck.new(args)
     expect(check.config[:password]).to eq 'foobar'
   end
 
   it 'sets socket option accordingly' do
-    args = %w(--socket /some/path/redis.sock)
+    args = %w[--socket /some/path/redis.sock]
     check = DummyRedisCheck.new(args)
     expect(check.config[:socket]).to eq '/some/path/redis.sock'
   end
 
   it 'prefers socket option over host:port' do
-    args = %w(--host 10.0.0.1 -port 3456 --socket /some/path/redis.sock)
+    args = %w[--host 10.0.0.1 -port 3456 --socket /some/path/redis.sock]
     check = DummyRedisCheck.new(args)
     expect(check.default_redis_options[:path]).to eq '/some/path/redis.sock'
     expect(check.default_redis_options[:host]).to be_nil
@@ -32,13 +32,13 @@ describe 'DummyRedisCheck', '#run' do
   end
 
   it 'output conn info for host:port' do
-    args = %w(--host 10.0.0.1 --port 3456)
+    args = %w[--host 10.0.0.1 --port 3456]
     check = DummyRedisCheck.new(args)
     expect(check.redis_endpoint).to eq '10.0.0.1:3456'
   end
 
   it 'output conn info for host:port' do
-    args = %w(--socket /some/path/redis.sock --host 10.0.0.1 --port 3456)
+    args = %w[--socket /some/path/redis.sock --host 10.0.0.1 --port 3456]
     check = DummyRedisCheck.new(args)
     expect(check.redis_endpoint).to eq 'unix:///some/path/redis.sock'
   end


### PR DESCRIPTION
Breaking Changes:
- removed ruby `< 2.1` support

Misc:
- appeased the cops

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

https://github.com/sensu-plugins/community/issues/77

#### General

- [ ] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass


#### Purpose
Address CVE, see parent issue for details
#### Known Compatibility Issues
dropped ruby `< 2.1` support