### PR TITLE
Feature/ssl support

### DIFF
--- a/lib/redis_client_options.rb
+++ b/lib/redis_client_options.rb
@@ -14,6 +14,7 @@ module RedisClientOptions
     opts[:password] = config[:password] if config[:password]
     opts[:timeout]  = config[:timeout]  if config[:timeout]
     opts[:db]       = config[:database] if config[:database]
+    opts[:scheme]   = config[:scheme] if config[:scheme]
 
     if config[:socket]
       opts[:path] = config[:socket]
@@ -67,6 +68,13 @@ module RedisClientOptions
              short: '-P PASSWORD',
              long: '--password PASSWORD',
              description: 'Redis Password to connect with'
+
+      option :scheme,
+             short: '-s SCHEME',
+             long: '--scheme SCHEME',
+             description: 'Redis transport protocol to use',
+             required: false,
+             default: Redis::Client::DEFAULTS[:scheme]
 
       option :conn_failure_status,
              long: '--conn-failure-status EXIT_STATUS',

--- a/lib/redis_client_options.rb
+++ b/lib/redis_client_options.rb
@@ -14,7 +14,7 @@ module RedisClientOptions
     opts[:password] = config[:password] if config[:password]
     opts[:timeout]  = config[:timeout]  if config[:timeout]
     opts[:db]       = config[:database] if config[:database]
-    opts[:scheme]   = config[:scheme] if config[:scheme]
+    opts[:scheme]   = config[:transport] if config[:transport]
 
     if config[:socket]
       opts[:path] = config[:socket]
@@ -69,12 +69,13 @@ module RedisClientOptions
              long: '--password PASSWORD',
              description: 'Redis Password to connect with'
 
-      option :scheme,
-             short: '-S SCHEME',
-             long: '--scheme SCHEME',
+      option :transport,
+             short: '-T TRANSPORT',
+             long: '--transport TRANSPORT',
              description: 'Redis transport protocol to use',
              required: false,
-             default: Redis::Client::DEFAULTS[:scheme]
+             default: Redis::Client::DEFAULTS[:scheme],
+             in: %w[redis rediss]
 
       option :conn_failure_status,
              long: '--conn-failure-status EXIT_STATUS',

--- a/lib/redis_client_options.rb
+++ b/lib/redis_client_options.rb
@@ -70,7 +70,7 @@ module RedisClientOptions
              description: 'Redis Password to connect with'
 
       option :scheme,
-             short: '-s SCHEME',
+             short: '-S SCHEME',
              long: '--scheme SCHEME',
              description: 'Redis transport protocol to use',
              required: false,

--- a/test/lib/redis_client_options_spec.rb
+++ b/test/lib/redis_client_options_spec.rb
@@ -42,4 +42,11 @@ describe 'DummyRedisCheck', '#run' do
     check = DummyRedisCheck.new(args)
     expect(check.redis_endpoint).to eq 'unix:///some/path/redis.sock'
   end
+
+  it 'sets transport protocol' do
+    args = %w[--transport redis]
+    check = DummyRedisCheck.new(args)
+    expect(check.config[:transport]).to eq 'redis'
+    expect(check.default_redis_options[:scheme]).to eq 'redis'
+  end
 end


### PR DESCRIPTION
## Pull Request Checklist

* Add the ability to set the `scheme` redis client option which opens up support for redis server configurations which use SSL.

This can be set on any of the plugin checks using `-T rediss` or `--transport rediss`

#### General

- [ ] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
