### PR TITLE
remove ruby `< 2.3` support and testing, update deps for `sensu-plugins`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+AllCops:
+  TargetRubyVersion: 2.3
 
 MethodLength:
   Max: 200

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ before_install:
 install:
 - bundle install
 rvm:
-- 2.1
-- 2.2
 - 2.3.0
 - 2.4.1
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+### Breaking Changes
+- dropping ruby support for `< 2.3` as they are EOL (@majormoses)
+- bump `sensu-plugin` dependency from `~> 1.2` to `~> 4.0` you can read the changelog entries for [4.0](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#400---2018-02-17), [3.0](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#300---2018-12-04), and [2.0](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v200---2017-03-29) (@majormoses)
+
 ## [3.1.1] - 2019-04-02
 ### Fixed
 - metrics-redis-graphite.rb: update list of skip keys in `SKIP_KEYS_REGEX` (@boutetnico)

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'github/markup'
 require 'redcarpet'

--- a/bin/check-redis-connections-available.rb
+++ b/bin/check-redis-connections-available.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: false
+
 #
 #   check-redis-connection.rb
 #

--- a/bin/check-redis-info.rb
+++ b/bin/check-redis-info.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: false
+
 #
 # Checks checks variables from redis INFO http://redis.io/commands/INFO
 #

--- a/bin/check-redis-keys.rb
+++ b/bin/check-redis-keys.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: false
+
 #
 # Checks number of keys matching a keys command are above the provided
 # warn/critical levels

--- a/bin/check-redis-list-length.rb
+++ b/bin/check-redis-list-length.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: false
+
 #
 # Checks number of items in a Redis list key
 # ===

--- a/bin/check-redis-memory-percentage.rb
+++ b/bin/check-redis-memory-percentage.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: false
+
 #
 #   check-redis-memory-percentage
 #

--- a/bin/check-redis-memory.rb
+++ b/bin/check-redis-memory.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: false
+
 #
 # Checks Redis INFO stats and limits values
 # ===

--- a/bin/check-redis-ping.rb
+++ b/bin/check-redis-ping.rb
@@ -1,4 +1,5 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: false
 
 #   <script name>
 #

--- a/bin/check-redis-slave-status.rb
+++ b/bin/check-redis-slave-status.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: false
+
 #
 # Checks Redis Slave Replication
 

--- a/bin/metrics-redis-graphite.rb
+++ b/bin/metrics-redis-graphite.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: false
+
 #
 # Push Redis INFO stats into graphite
 # ===

--- a/bin/metrics-redis-llen.rb
+++ b/bin/metrics-redis-llen.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: false
+
 #
 # Get the length of a list and push it to graphite
 #

--- a/lib/redis_client_options.rb
+++ b/lib/redis_client_options.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require 'redis'
 require 'sensu-plugin/metric/cli'
 

--- a/lib/sensu-plugins-redis.rb
+++ b/lib/sensu-plugins-redis.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'sensu-plugins-redis/version'

--- a/lib/sensu-plugins-redis/version.rb
+++ b/lib/sensu-plugins-redis/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SensuPluginsRedis
   module Version
     MAJOR = 3

--- a/sensu-plugins-redis.gemspec
+++ b/sensu-plugins-redis.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
@@ -28,25 +30,24 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.1.0'
+  s.required_ruby_version  = '>= 2.3.0'
 
   s.summary                = 'Sensu plugins for working with redis'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsRedis::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin', '~> 4.0'
 
   s.add_runtime_dependency 'redis',        '~> 3.3'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
-  s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
-  s.add_development_dependency 'github-markup',             '~> 1.3'
+  s.add_development_dependency 'github-markup',             '~> 3.0'
   s.add_development_dependency 'kitchen-docker',            '~> 2.6'
   s.add_development_dependency 'kitchen-localhost',         '~> 0.3'
   # locked to keep ruby 2.1 support, this is pulled in by test-kitchen
   s.add_development_dependency 'mixlib-shellout',           ['< 2.3.0', '~> 2.2']
   s.add_development_dependency 'pry',                       '~> 0.10'
-  s.add_development_dependency 'rake',                      '~> 10.0'
+  s.add_development_dependency 'rake',                      '~> 12.3'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.1'
   s.add_development_dependency 'rubocop',                   '~> 0.51.0'

--- a/test/bin/check-redis-connections-available_spec.rb
+++ b/test/bin/check-redis-connections-available_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require_relative '../spec_helper.rb'
 require_relative '../../bin/check-redis-connections-available.rb'
 

--- a/test/bin/check-redis-info_spec.rb
+++ b/test/bin/check-redis-info_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require_relative '../spec_helper.rb'
 require_relative '../../bin/check-redis-info.rb'
 

--- a/test/bin/check-redis-keys_spec.rb
+++ b/test/bin/check-redis-keys_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require_relative '../spec_helper.rb'
 require_relative '../../bin/check-redis-keys.rb'
 

--- a/test/bin/check-redis-list-length_spec.rb
+++ b/test/bin/check-redis-list-length_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require_relative '../spec_helper.rb'
 require_relative '../../bin/check-redis-list-length.rb'
 

--- a/test/bin/check-redis-memory-percentage_spec.rb
+++ b/test/bin/check-redis-memory-percentage_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require_relative '../spec_helper.rb'
 require_relative '../../bin/check-redis-memory-percentage.rb'
 

--- a/test/bin/check-redis-memory_spec.rb
+++ b/test/bin/check-redis-memory_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require_relative '../spec_helper.rb'
 require_relative '../../bin/check-redis-memory.rb'
 

--- a/test/bin/check-redis-ping_spec.rb
+++ b/test/bin/check-redis-ping_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require_relative '../spec_helper.rb'
 require_relative '../../bin/check-redis-ping.rb'
 

--- a/test/bin/check-redis-slave-status_spec.rb
+++ b/test/bin/check-redis-slave-status_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require_relative '../spec_helper.rb'
 require_relative '../../bin/check-redis-slave-status.rb'
 

--- a/test/bin/metrics-redis-graphite_spec.rb
+++ b/test/bin/metrics-redis-graphite_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require_relative '../spec_helper.rb'
 require_relative '../../bin/metrics-redis-graphite.rb'
 

--- a/test/bin/metrics-redis-llen_spec.rb
+++ b/test/bin/metrics-redis-llen_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require_relative '../spec_helper.rb'
 require_relative '../../bin/metrics-redis-llen.rb'
 

--- a/test/lib/redis_client_options_spec.rb
+++ b/test/lib/redis_client_options_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require_relative '../spec_helper.rb'
 require_relative '../../lib/redis_client_options.rb'
 require 'redis'

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,2 +1,1 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+# frozen_string_literal: false


### PR DESCRIPTION
Updating Multiple non runtime deps, removed code climate.

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

https://github.com/sensu-plugins/community/issues/26


#### General

- [ ] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose
- Drop unsupported rubies, speed up CI.
- update some deps

#### Known Compatibility Issues
- Drops support for ruby `< 2.3`
- update `sensu-plugin` dep see changelog for details